### PR TITLE
Fix duplicate variable declarations in AdminMonthEnd.vue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@types/uuid": "^10.0.0",
         "@vee-validate/zod": "^4.15.1",
         "@vueuse/core": "^13.4.0",
+        "@zodios/core": "^10.9.6",
         "ag-grid-community": "^33.3.2",
         "ag-grid-vue3": "^33.3.2",
         "axios": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@types/uuid": "^10.0.0",
     "@vee-validate/zod": "^4.15.1",
     "@vueuse/core": "^13.4.0",
+    "@zodios/core": "^10.9.6",
     "ag-grid-community": "^33.3.2",
     "ag-grid-vue3": "^33.3.2",
     "axios": "^1.9.0",

--- a/src/views/AdminMonthEnd.vue
+++ b/src/views/AdminMonthEnd.vue
@@ -225,17 +225,16 @@ const stockJob = ref<MonthEndStockJob | null>(null)
 const isLoading = computed(() => loading.value)
 const totalHours = computed(() => jobs.value.reduce((a, j) => a + j.total_hours, 0))
 const totalDollars = computed(() => jobs.value.reduce((a, j) => a + j.total_dollars, 0))
-const allSelected =
-  computed(() => jobs.value.length > 0 && selectedIds.value.length === jobs.value.length) |
-  (null > null)
-
-const jobs = ref<MonthEndJob[]>([])
-const stockJob = ref<MonthEndStockJob | null>(null)
-const totalHours = computed(() => jobs.value.reduce((a, j) => a + j.total_hours, 0))
-const totalDollars = computed(() => jobs.value.reduce((a, j) => a + j.total_dollars, 0))
 const allSelected = computed(
   () => jobs.value.length > 0 && selectedIds.value.length === jobs.value.length,
 )
+const showDialog = ref(false)
+const progress = ref(0)
+const customMonthLoaded = ref(false)
+const customMonthData = ref<{
+  jobs: MonthEndJob[]
+  stockSummary: { material_line_count: number; material_cost: number }
+} | null>(null)
 const stockSummary = computed(() => {
   if (!stockJob.value) return { material_line_count: 0, material_cost: 0 }
   return {


### PR DESCRIPTION
- Remove duplicate declarations for jobs, stockJob, totalHours, totalDollars, allSelected
- Fix malformed allSelected computed property syntax
- Add missing variable declarations: showDialog, progress, customMonthLoaded, customMonthData
- Install missing @zodios/core dependency for build compatibility

🤖 Generated with [Claude Code](https://claude.ai/code)

## 📝 Description

_Short explanation of what you’ve built and why._

## 🔗 Related Issue

Closes #[issue-number]

## 🚀 Changes

- Bullet-list of feature additions or fixes (e.g. extracted `useChat` composable, split `ChatHistory` and `ChatInput` components, added Pinia store).
- …

## ✅ Checklist

**Vue.js (Composition API)**

- [ ] Used Composition API (`<script setup>` & composables), no heavy logic in templates
- [ ] UI logic extracted to reusable composables (`useChat`, etc.)
- [ ] Components are focused & small (<200 LOC)
- [ ] Communication via `props` and `emit`, no direct parent/child ref duplication
- [ ] State management in Pinia; no ad-hoc reactive globals
- [ ] Routes/components lazy-loaded where appropriate

**Quality & Formatting**

- [ ] Passes Prettier (`npx prettier --check .`)
- [ ] Passes ESLint with zero warnings (`npx eslint . --ext .js,.ts,.vue`)
- [ ] Added JSDoc comments for all props and emitted events
- [ ] New or updated unit/E2E tests included
