### PR TITLE
fix: replace local Xero schemas with generated API types

### DIFF
--- a/schema.yml
+++ b/schema.yml
@@ -949,6 +949,210 @@ paths:
               schema:
                 $ref: '#/components/schemas/AppError'
           description: ''
+  /api/xero/create_invoice/{job_id}:
+    post:
+      operationId: api_xero_create_invoice_create
+      description: Creates an invoice in Xero for the specified job
+      parameters:
+        - in: path
+          name: job_id
+          schema:
+            type: string
+            format: uuid
+          required: true
+      tags:
+        - api
+      security:
+        - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/XeroOperationResponse'
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/XeroOperationResponse'
+          description: ''
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/XeroOperationResponse'
+          description: ''
+  /api/xero/create_purchase_order/{purchase_order_id}:
+    post:
+      operationId: api_xero_create_purchase_order_create
+      description: Creates a purchase order in Xero for the specified purchase order
+      parameters:
+        - in: path
+          name: purchase_order_id
+          schema:
+            type: string
+            format: uuid
+          required: true
+      tags:
+        - api
+      security:
+        - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/XeroOperationResponse'
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/XeroOperationResponse'
+          description: ''
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/XeroOperationResponse'
+          description: ''
+  /api/xero/create_quote/{job_id}:
+    post:
+      operationId: api_xero_create_quote_create
+      description: Creates a quote in Xero for the specified job
+      parameters:
+        - in: path
+          name: job_id
+          schema:
+            type: string
+            format: uuid
+          required: true
+      tags:
+        - api
+      security:
+        - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/XeroOperationResponse'
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/XeroOperationResponse'
+          description: ''
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/XeroOperationResponse'
+          description: ''
+  /api/xero/delete_invoice/{job_id}:
+    delete:
+      operationId: api_xero_delete_invoice_destroy
+      description: Deletes an invoice in Xero for the specified job
+      parameters:
+        - in: path
+          name: job_id
+          schema:
+            type: string
+            format: uuid
+          required: true
+      tags:
+        - api
+      security:
+        - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/XeroOperationResponse'
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/XeroOperationResponse'
+          description: ''
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/XeroOperationResponse'
+          description: ''
+  /api/xero/delete_purchase_order/{purchase_order_id}:
+    delete:
+      operationId: api_xero_delete_purchase_order_destroy
+      description: Deletes a purchase order in Xero for the specified purchase order
+      parameters:
+        - in: path
+          name: purchase_order_id
+          schema:
+            type: string
+            format: uuid
+          required: true
+      tags:
+        - api
+      security:
+        - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/XeroOperationResponse'
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/XeroOperationResponse'
+          description: ''
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/XeroOperationResponse'
+          description: ''
+  /api/xero/delete_quote/{job_id}:
+    delete:
+      operationId: api_xero_delete_quote_destroy
+      description: Deletes a quote in Xero for the specified job
+      parameters:
+        - in: path
+          name: job_id
+          schema:
+            type: string
+            format: uuid
+          required: true
+      tags:
+        - api
+      security:
+        - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/XeroOperationResponse'
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/XeroOperationResponse'
+          description: ''
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/XeroOperationResponse'
+          description: ''
   /app-errors/:
     get:
       operationId: app_errors_list
@@ -2102,7 +2306,7 @@ paths:
   /job/rest/jobs/{job_id}/:
     get:
       operationId: job_rest_jobs_retrieve
-      description: Fetch complete Job data for editing.
+      description: Fetch complete job data including financial information
       parameters:
         - in: path
           name: job_id
@@ -7965,6 +8169,20 @@ components:
           type: integer
       required:
         - items
+    XeroOperationResponse:
+      type: object
+      description: Serializer for Xero operation responses (create/delete).
+      properties:
+        success:
+          type: boolean
+        error:
+          type: string
+        messages:
+          type: array
+          items:
+            type: string
+      required:
+        - success
   securitySchemes:
     cookieAuth:
       type: apiKey

--- a/src/api/generated/api.ts
+++ b/src/api/generated/api.ts
@@ -401,6 +401,13 @@ const PaginatedAppErrorList = z
     results: z.array(AppError),
   })
   .passthrough()
+const XeroOperationResponse = z
+  .object({
+    success: z.boolean(),
+    error: z.string().optional(),
+    messages: z.array(z.string()).optional(),
+  })
+  .passthrough()
 const ClientContactResult = z
   .object({
     id: z.string(),
@@ -1354,6 +1361,7 @@ export const schemas = {
   PatchedAIProviderCreateUpdate,
   AppError,
   PaginatedAppErrorList,
+  XeroOperationResponse,
   ClientContactResult,
   ClientContactsResponse,
   ClientListResponse,
@@ -2124,6 +2132,156 @@ Endpoints:
       },
     ],
     response: AppError,
+  },
+  {
+    method: 'post',
+    path: '/api/xero/create_invoice/:job_id',
+    alias: 'api_xero_create_invoice_create',
+    description: `Creates an invoice in Xero for the specified job`,
+    requestFormat: 'json',
+    parameters: [
+      {
+        name: 'job_id',
+        type: 'Path',
+        schema: z.string().uuid(),
+      },
+    ],
+    response: XeroOperationResponse,
+    errors: [
+      {
+        status: 404,
+        schema: XeroOperationResponse,
+      },
+      {
+        status: 500,
+        schema: XeroOperationResponse,
+      },
+    ],
+  },
+  {
+    method: 'post',
+    path: '/api/xero/create_purchase_order/:purchase_order_id',
+    alias: 'api_xero_create_purchase_order_create',
+    description: `Creates a purchase order in Xero for the specified purchase order`,
+    requestFormat: 'json',
+    parameters: [
+      {
+        name: 'purchase_order_id',
+        type: 'Path',
+        schema: z.string().uuid(),
+      },
+    ],
+    response: XeroOperationResponse,
+    errors: [
+      {
+        status: 404,
+        schema: XeroOperationResponse,
+      },
+      {
+        status: 500,
+        schema: XeroOperationResponse,
+      },
+    ],
+  },
+  {
+    method: 'post',
+    path: '/api/xero/create_quote/:job_id',
+    alias: 'api_xero_create_quote_create',
+    description: `Creates a quote in Xero for the specified job`,
+    requestFormat: 'json',
+    parameters: [
+      {
+        name: 'job_id',
+        type: 'Path',
+        schema: z.string().uuid(),
+      },
+    ],
+    response: XeroOperationResponse,
+    errors: [
+      {
+        status: 404,
+        schema: XeroOperationResponse,
+      },
+      {
+        status: 500,
+        schema: XeroOperationResponse,
+      },
+    ],
+  },
+  {
+    method: 'delete',
+    path: '/api/xero/delete_invoice/:job_id',
+    alias: 'api_xero_delete_invoice_destroy',
+    description: `Deletes an invoice in Xero for the specified job`,
+    requestFormat: 'json',
+    parameters: [
+      {
+        name: 'job_id',
+        type: 'Path',
+        schema: z.string().uuid(),
+      },
+    ],
+    response: XeroOperationResponse,
+    errors: [
+      {
+        status: 404,
+        schema: XeroOperationResponse,
+      },
+      {
+        status: 500,
+        schema: XeroOperationResponse,
+      },
+    ],
+  },
+  {
+    method: 'delete',
+    path: '/api/xero/delete_purchase_order/:purchase_order_id',
+    alias: 'api_xero_delete_purchase_order_destroy',
+    description: `Deletes a purchase order in Xero for the specified purchase order`,
+    requestFormat: 'json',
+    parameters: [
+      {
+        name: 'purchase_order_id',
+        type: 'Path',
+        schema: z.string().uuid(),
+      },
+    ],
+    response: XeroOperationResponse,
+    errors: [
+      {
+        status: 404,
+        schema: XeroOperationResponse,
+      },
+      {
+        status: 500,
+        schema: XeroOperationResponse,
+      },
+    ],
+  },
+  {
+    method: 'delete',
+    path: '/api/xero/delete_quote/:job_id',
+    alias: 'api_xero_delete_quote_destroy',
+    description: `Deletes a quote in Xero for the specified job`,
+    requestFormat: 'json',
+    parameters: [
+      {
+        name: 'job_id',
+        type: 'Path',
+        schema: z.string().uuid(),
+      },
+    ],
+    response: XeroOperationResponse,
+    errors: [
+      {
+        status: 404,
+        schema: XeroOperationResponse,
+      },
+      {
+        status: 500,
+        schema: XeroOperationResponse,
+      },
+    ],
   },
   {
     method: 'get',
@@ -2977,7 +3135,7 @@ POST /job/rest/jobs/&lt;uuid:pk&gt;/quote/preview/`,
     method: 'get',
     path: '/job/rest/jobs/:job_id/',
     alias: 'job_rest_jobs_retrieve',
-    description: `Fetch complete Job data for editing.`,
+    description: `Fetch complete job data including financial information`,
     requestFormat: 'json',
     parameters: [
       {

--- a/src/components/job/JobFinancialTab.vue
+++ b/src/components/job/JobFinancialTab.vue
@@ -243,11 +243,10 @@ import { debugLog } from '../../utils/debug'
 import { computed, ref, watch } from 'vue'
 import axios from 'axios'
 import { toast } from 'vue-sonner'
-import { XeroSyncResponseSchema, type JobWithFinancialData } from '../../api/local/schemas'
-import { api } from '../../api/generated/api'
+import { api, XeroOperationResponse, type Job } from '../../api/generated/api'
 
 interface Props {
-  jobData: JobWithFinancialData | null
+  jobData: Job | null
   latestPricings?: Record<string, unknown>
   jobId?: string
 }
@@ -359,10 +358,11 @@ const createQuote = async () => {
   try {
     // TODO: This endpoint needs to be added to the OpenAPI spec to use Zodios
     // Xero integration endpoints are not yet available in the generated API
-    const response = await axios.post(`/api/xero/create_quote/${props.jobData.id}`)
-    const validatedResponse = XeroSyncResponseSchema.parse(response.data)
-    if (!validatedResponse.success) {
-      debugLog(validatedResponse.error || 'Failed to create quote')
+    const response = await axios.post<XeroOperationResponse>(
+      `/api/xero/create_quote/${props.jobData.id}`,
+    )
+    if (!response.data.success) {
+      debugLog(response.data.error || 'Failed to create quote')
       return
     }
     toast.success('Quote created successfully!')
@@ -407,10 +407,11 @@ const createInvoice = async () => {
   try {
     // TODO: This endpoint needs to be added to the OpenAPI spec to use Zodios
     // Xero integration endpoints are not yet available in the generated API
-    const response = await axios.post(`/api/xero/create_invoice/${props.jobData.id}`)
-    const validatedResponse = XeroSyncResponseSchema.parse(response.data)
-    if (!validatedResponse.success) {
-      debugLog(validatedResponse.error || 'Failed to create invoice')
+    const response = await axios.post<XeroOperationResponse>(
+      `/api/xero/create_invoice/${props.jobData.id}`,
+    )
+    if (!response.data.success) {
+      debugLog(response.data.error || 'Failed to create invoice')
       return
     }
     toast.success('Invoice created successfully!')
@@ -438,10 +439,11 @@ const deleteQuoteOnXero = async () => {
   try {
     // TODO: This endpoint needs to be added to the OpenAPI spec to use Zodios
     // Xero integration endpoints are not yet available in the generated API
-    const response = await axios.post(`/api/xero/delete_quote/${props.jobData.id}`)
-    const validatedResponse = XeroSyncResponseSchema.parse(response.data)
-    if (!validatedResponse.success) {
-      debugLog(validatedResponse.error || 'Failed to delete quote')
+    const response = await axios.delete<XeroOperationResponse>(
+      `/api/xero/delete_quote/${props.jobData.id}`,
+    )
+    if (!response.data.success) {
+      debugLog(response.data.error || 'Failed to delete quote')
       return
     }
 
@@ -471,10 +473,11 @@ const deleteInvoiceOnXero = async () => {
   try {
     // TODO: This endpoint needs to be added to the OpenAPI spec to use Zodios
     // Xero integration endpoints are not yet available in the generated API
-    const response = await axios.post(`/api/xero/delete_invoice/${props.jobData.id}`)
-    const validatedResponse = XeroSyncResponseSchema.parse(response.data)
-    if (!validatedResponse.success) {
-      debugLog(validatedResponse.error || 'Failed to delete invoice')
+    const response = await axios.delete<XeroOperationResponse>(
+      `/api/xero/delete_invoice/${props.jobData.id}`,
+    )
+    if (!response.data.success) {
+      debugLog(response.data.error || 'Failed to delete invoice')
       return
     }
 


### PR DESCRIPTION
- Replace XeroSyncResponseSchema with generated XeroOperationResponse type
- Update JobFinancialTab to use Job type instead of JobWithFinancialData
- Fix HTTP methods for Xero delete operations (POST → DELETE)
- Remove duplicate schema validation in favor of generated types

🤖 Generated with [Claude Code](https://claude.ai/code)

## 📝 Description

_Short explanation of what you’ve built and why._

## 🔗 Related Issue

Closes #[issue-number]

## 🚀 Changes

- Bullet-list of feature additions or fixes (e.g. extracted `useChat` composable, split `ChatHistory` and `ChatInput` components, added Pinia store).
- …

## ✅ Checklist

**Vue.js (Composition API)**

- [ ] Used Composition API (`<script setup>` & composables), no heavy logic in templates
- [ ] UI logic extracted to reusable composables (`useChat`, etc.)
- [ ] Components are focused & small (<200 LOC)
- [ ] Communication via `props` and `emit`, no direct parent/child ref duplication
- [ ] State management in Pinia; no ad-hoc reactive globals
- [ ] Routes/components lazy-loaded where appropriate

**Quality & Formatting**

- [ ] Passes Prettier (`npx prettier --check .`)
- [ ] Passes ESLint with zero warnings (`npx eslint . --ext .js,.ts,.vue`)
- [ ] Added JSDoc comments for all props and emitted events
- [ ] New or updated unit/E2E tests included
