### PR TITLE
Refactor: fix timesheet regressions and enhance navigation flow

### DIFF
--- a/schema.yml
+++ b/schema.yml
@@ -4773,6 +4773,13 @@ paths:
     get:
       operationId: timesheets_api_staff_retrieve
       description: Get filtered list of staff members for a specific date.
+      summary: Returns staff members excluding system and users for a specific date
+      parameters:
+        - in: query
+          name: date
+          schema:
+            type: string
+          description: Date parameter in format YYYY-MM-DD
       tags:
         - timesheets
       security:
@@ -6212,6 +6219,7 @@ components:
           type: string
         leave_type:
           type: string
+          nullable: true
         has_leave:
           type: boolean
           default: false
@@ -6268,8 +6276,6 @@ components:
           items:
             type: string
             format: date
-        week_start:
-          type: string
         staff_data:
           type: array
           items:
@@ -6297,7 +6303,6 @@ components:
         - start_date
         - summary_stats
         - week_days
-        - week_start
         - weekly_summary
     Job:
       type: object
@@ -7674,6 +7679,7 @@ components:
         client_name:
           type: string
           readOnly: true
+          nullable: true
         status:
           $ref: '#/components/schemas/Status7b9Enum'
         charge_out_rate:
@@ -9098,6 +9104,16 @@ components:
           type: string
           format: decimal
           pattern: ^-?\d{0,8}(?:\.\d{0,2})?$
+        unit_cost:
+          type: string
+          format: decimal
+          pattern: ^-?\d{0,8}(?:\.\d{0,2})?$
+          nullable: true
+        unit_rev:
+          type: string
+          format: decimal
+          pattern: ^-?\d{0,8}(?:\.\d{0,2})?$
+          nullable: true
       required:
         - job_id
         - quantity
@@ -9458,8 +9474,10 @@ components:
           type: string
         client:
           type: string
+          nullable: true
         description:
           type: string
+          nullable: true
         status:
           type: string
         people:
@@ -9478,8 +9496,6 @@ components:
           format: double
       required:
         - actual_hours
-        - client
-        - description
         - estimated_hours
         - job_id
         - job_number
@@ -9491,7 +9507,7 @@ components:
       type: object
       description: Serializer for staff data in weekly timesheet context
       properties:
-        id:
+        staff_id:
           type: string
           format: uuid
         name:
@@ -9500,24 +9516,61 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/WeeklyStaffDataWeeklyHours'
+        total_hours:
+          type: string
+          format: decimal
+          pattern: ^-?\d{0,8}(?:\.\d{0,2})?$
+        total_billable_hours:
+          type: string
+          format: decimal
+          pattern: ^-?\d{0,8}(?:\.\d{0,2})?$
+        billable_percentage:
+          type: string
+          format: decimal
+          pattern: ^-?\d{0,3}(?:\.\d{0,2})?$
+        status:
+          type: string
       required:
-        - id
+        - billable_percentage
         - name
+        - staff_id
+        - status
+        - total_billable_hours
+        - total_hours
         - weekly_hours
     WeeklyStaffDataWeeklyHours:
       type: object
       description: Serializer for weekly hours data of staff
       properties:
-        date:
+        day:
           type: string
           format: date
         hours:
           type: string
           format: decimal
           pattern: ^-?\d{0,3}(?:\.\d{0,2})?$
+        billable_hours:
+          type: string
+          format: decimal
+          pattern: ^-?\d{0,3}(?:\.\d{0,2})?$
+        scheduled_hours:
+          type: string
+          format: decimal
+          pattern: ^-?\d{0,3}(?:\.\d{0,2})?$
+        status:
+          type: string
+        leave_type:
+          type: string
+          nullable: true
+        has_leave:
+          type: boolean
       required:
-        - date
+        - billable_hours
+        - day
+        - has_leave
         - hours
+        - scheduled_hours
+        - status
     WeeklySummary:
       type: object
       description: Serializer for weekly summary data
@@ -9551,8 +9604,6 @@ components:
           items:
             type: string
             format: date
-        week_start:
-          type: string
         staff_data:
           type: array
           items:
@@ -9580,7 +9631,6 @@ components:
         - start_date
         - summary_stats
         - week_days
-        - week_start
         - weekly_summary
     WorkshopPDFResponse:
       type: object

--- a/src/components/job/JobFinancialTab.vue
+++ b/src/components/job/JobFinancialTab.vue
@@ -245,6 +245,7 @@ import { toast } from 'vue-sonner'
 import { schemas } from '@/api/generated/api'
 import { z } from 'zod'
 import { api } from '@/api/client'
+import { AxiosError } from 'axios'
 
 type Job = z.infer<typeof schemas.Job>
 
@@ -415,9 +416,14 @@ const createInvoice = async () => {
     toast.success('Invoice created successfully!')
     isInvoiceDeleted.value = false
     emit('invoice-created')
-  } catch (err) {
+  } catch (err: unknown) {
+    let msg = 'Unexpected error while trying to create invoice.'
     debugLog('Error creating invoice:', err)
-    toast.error('Failed to create invoice.')
+    if ((err as AxiosError).isAxiosError) {
+      const axiosErr = err as AxiosError<{ message: string }>
+      msg = axiosErr.response?.data?.message ?? msg
+    }
+    toast.error(`Failed to create invoice: ${msg}`)
   } finally {
     isCreatingInvoice.value = false
   }

--- a/src/components/timesheet/BillablePercentageBadge.vue
+++ b/src/components/timesheet/BillablePercentageBadge.vue
@@ -13,19 +13,25 @@ import { computed } from 'vue'
 import { TrendingUp } from 'lucide-vue-next'
 
 const props = defineProps<{
-  percentage?: number
+  percentage?: number | string
 }>()
 
+const numericPercentage = computed(() => {
+  if (props.percentage === undefined || props.percentage === null) return null
+  const numeric =
+    typeof props.percentage === 'string' ? parseFloat(props.percentage) : props.percentage
+  return isNaN(numeric) ? null : numeric
+})
+
 const displayValue = computed(() => {
-  if (props.percentage === undefined || props.percentage === null) return '--'
-  return `${props.percentage.toFixed(1)}%`
+  if (numericPercentage.value === null) return '--'
+  return `${numericPercentage.value.toFixed(1)}%`
 })
 
 const badgeClass = computed(() => {
-  if (props.percentage === undefined || props.percentage === null)
-    return 'bg-gray-100 text-gray-500'
-  if (props.percentage >= 80) return 'bg-green-100 text-green-700'
-  if (props.percentage >= 50) return 'bg-yellow-100 text-yellow-700'
+  if (numericPercentage.value === null) return 'bg-gray-100 text-gray-500'
+  if (numericPercentage.value >= 80) return 'bg-green-100 text-green-700'
+  if (numericPercentage.value >= 50) return 'bg-yellow-100 text-yellow-700'
   return 'bg-red-100 text-red-700'
 })
 </script>

--- a/src/components/timesheet/TimesheetEntryJobCellEditor.ts
+++ b/src/components/timesheet/TimesheetEntryJobCellEditor.ts
@@ -433,15 +433,21 @@ export class TimesheetEntryJobCellEditor implements ICellEditor {
         }
       }
 
-      const currentStaff = (window as unknown as { currentStaff?: { wageRate?: number } })
-        .currentStaff
-      const companyDefaults = (window as unknown as { companyDefaults?: { wage_rate?: number } })
-        .companyDefaults
-      const wageRate = currentStaff?.wageRate || companyDefaults?.wage_rate || 32
+      const wageRate =
+        typeof rowData.wageRate === 'string' ? parseFloat(rowData.wageRate) : rowData.wageRate || 0
       const multiplier = getRateMultiplier(rate)
-      rowData.wage = hours > 0 ? Math.round(hours * wageRate * multiplier * 100) / 100 : 0
 
-      debugLog('💰 Using wage rate:', wageRate, 'for', hours, 'hours with multiplier', multiplier)
+      // If no wageRate in rowData, DO NOT calculate wage - let the grid composable handle it
+      if (wageRate > 0) {
+        rowData.wage = hours > 0 ? Math.round(hours * wageRate * multiplier * 100) / 100 : 0
+        debugLog('💰 Using wage rate:', wageRate, 'for', hours, 'hours with multiplier', multiplier)
+      } else {
+        // Do not set wage to 0 - leave it undefined so grid composable can calculate it
+        debugLog(
+          '⚠️ No wageRate in rowData - leaving wage calculation to grid composable. RowData wageRate:',
+          rowData.wageRate,
+        )
+      }
 
       const chargeOutRateNum = parseFloat(chargeOutRate) || 0
       rowData.bill =

--- a/src/components/timesheet/WeeklyMetricsModal.vue
+++ b/src/components/timesheet/WeeklyMetricsModal.vue
@@ -537,7 +537,7 @@ const loadJobs = async () => {
   isLoading.value = true
   try {
     const params = props.weekDate ? { week: props.weekDate } : undefined
-    const response = await api.getWeeklyMetrics(params)
+    const response = await api.job_rest_jobs_weekly_metrics_list(params)
     jobs.value = response || []
     console.log(`📊 Loaded ${jobs.value.length} jobs for week: ${props.weekDate || 'current'}`)
   } catch (error) {

--- a/src/composables/useTimesheetEntryCalculations.ts
+++ b/src/composables/useTimesheetEntryCalculations.ts
@@ -29,7 +29,19 @@ export function useTimesheetEntryCalculations(companyDefaults: Ref<CompanyDefaul
     if (hours <= 0 || wageRate <= 0) return 0
 
     const multiplier = getRateMultiplier(rateType)
-    return Math.round(hours * wageRate * multiplier * 100) / 100
+    // ✅ CORRECT FORMULA: hours × rate_multiplier × staff_wage_rate
+    const calculatedWage = Math.round(hours * multiplier * wageRate * 100) / 100
+
+    debugLog('💰 Calculating wage:', {
+      hours,
+      rateType,
+      multiplier,
+      wageRate,
+      calculatedWage,
+      formula: `${hours} × ${multiplier} × ${wageRate} = ${calculatedWage}`,
+    })
+
+    return calculatedWage
   }
 
   const calculateBill = (hours: number, chargeOutRate: number, billable: boolean): number => {
@@ -62,23 +74,47 @@ export function useTimesheetEntryCalculations(companyDefaults: Ref<CompanyDefaul
   }
 
   const createNewRow = (staffMember: Staff, date: string): TimesheetEntryWithMeta => {
-    const defaultWageRate = companyDefaults.value?.wage_rate || 32.0
-    const defaultChargeOutRate = companyDefaults.value?.charge_out_rate || 105.0
+    // NO FALLBACKS - Use only actual staff wage rate
+    const staffWageRate =
+      typeof staffMember.wageRate === 'string'
+        ? parseFloat(staffMember.wageRate)
+        : staffMember.wageRate || 0
+    const defaultChargeOutRate = companyDefaults.value?.charge_out_rate || 0
+    const hours = 0
+    const rateMultiplier = 1.0 // Default 'Ord' rate
+
+    // ✅ CORRECT WAGE CALCULATION: hours × rate_multiplier × staff_wage_rate
+    const calculatedWage =
+      hours > 0 && staffWageRate > 0
+        ? Math.round(hours * rateMultiplier * staffWageRate * 100) / 100
+        : 0
+
+    debugLog('🏗️ Creating new row with correct wage calculation:', {
+      staffId: staffMember.id,
+      staffWageRate,
+      hours,
+      rateMultiplier,
+      calculatedWage,
+      formula: `${hours} × ${rateMultiplier} × ${staffWageRate} = ${calculatedWage}`,
+      defaultChargeOutRate,
+      companyDefaults: companyDefaults.value,
+    })
 
     return {
       id: null, // Will be set by backend
       kind: 'time' as const,
       desc: '',
-      quantity: '0',
-      unit_cost: defaultWageRate.toString(),
+      quantity: hours.toString(),
+      unit_cost: staffWageRate.toString(), // This is the hourly rate, not the total wage
       unit_rev: defaultChargeOutRate.toString(),
-      total_cost: 0,
+      total_cost: calculatedWage, // ✅ CORRECT: hours × rate_multiplier × staff_wage_rate
       total_rev: 0,
       ext_refs: {},
       meta: {
         date,
         staff_id: staffMember.id,
         rate_type: 'Ord',
+        rate_multiplier: rateMultiplier,
         is_billable: true,
       },
       job_id: '',
@@ -91,6 +127,19 @@ export function useTimesheetEntryCalculations(companyDefaults: Ref<CompanyDefaul
       _isSaving: false,
       isNewRow: true,
       isModified: false,
+      // Include staff wage rate for grid calculations
+      wageRate: staffWageRate,
+      staffId: staffMember.id,
+      staffName: staffMember.name || '',
+      date,
+      hours,
+      description: '',
+      rate: 'Ord',
+      wage: calculatedWage, // ✅ CORRECT: Calculated wage using proper formula
+      bill: 0,
+      billable: true,
+      chargeOutRate: defaultChargeOutRate,
+      rateMultiplier,
     }
   }
 
@@ -173,13 +222,65 @@ export function useTimesheetEntryCalculations(companyDefaults: Ref<CompanyDefaul
     }
   }
 
-  const fromCostLine = (costLine: CostLine, staffId: string): TimesheetEntryWithMeta => {
+  const fromCostLine = (
+    costLine: CostLine,
+    staffId: string,
+    staffData?: Staff,
+  ): TimesheetEntryWithMeta => {
     if (!costLine || costLine.kind !== 'time') {
       throw new Error('Invalid cost line for time entry conversion')
     }
 
     // Type guard for meta object
     const metaObj = costLine.meta && typeof costLine.meta === 'object' ? costLine.meta : {}
+
+    // Extract wage rate from unit_cost (which should be the staff wage rate)
+    const wageRate =
+      typeof costLine.unit_cost === 'string'
+        ? parseFloat(costLine.unit_cost)
+        : costLine.unit_cost || 0
+    const staffWageRate = staffData?.wageRate
+      ? typeof staffData.wageRate === 'string'
+        ? parseFloat(staffData.wageRate)
+        : staffData.wageRate
+      : wageRate
+
+    // Get rate multiplier from backend data (rate_multiplier in meta)
+    const backendRateMultiplier =
+      metaObj && 'rate_multiplier' in metaObj && typeof metaObj.rate_multiplier === 'number'
+        ? metaObj.rate_multiplier
+        : 1.0
+    const hours = parseFloat(costLine.quantity || '0')
+
+    // ✅ ALWAYS USE CORRECT FORMULA: hours × rate_multiplier × staff_wage_rate
+    const calculatedWage =
+      hours > 0 && staffWageRate > 0
+        ? Math.round(hours * backendRateMultiplier * staffWageRate * 100) / 100
+        : 0
+
+    debugLog('🔄 Converting from CostLine with correct wage calculation:', {
+      costLineId: costLine.id,
+      hours,
+      staffWageRate,
+      backendRateMultiplier,
+      calculatedWage,
+      formula: `${hours} × ${backendRateMultiplier} × ${staffWageRate} = ${calculatedWage}`,
+      backendWage: costLine.total_cost,
+    })
+
+    // Determine rate type from multiplier
+    const rateType = (() => {
+      switch (backendRateMultiplier) {
+        case 1.5:
+          return '1.5'
+        case 2.0:
+          return '2.0'
+        case 0.0:
+          return 'Unpaid'
+        default:
+          return 'Ord'
+      }
+    })()
 
     return {
       id: costLine.id || null,
@@ -188,12 +289,13 @@ export function useTimesheetEntryCalculations(companyDefaults: Ref<CompanyDefaul
       quantity: costLine.quantity || '0',
       unit_cost: costLine.unit_cost || '0',
       unit_rev: costLine.unit_rev || '0',
-      total_cost: costLine.total_cost || 0,
+      total_cost: calculatedWage, // ✅ ALWAYS use calculated wage
       total_rev: costLine.total_rev || 0,
       ext_refs: costLine.ext_refs || {},
       meta: {
         ...metaObj,
         staff_id: staffId,
+        rate_multiplier: backendRateMultiplier,
       },
       job_id:
         metaObj && 'job_id' in metaObj && typeof metaObj.job_id === 'string' ? metaObj.job_id : '',
@@ -215,6 +317,19 @@ export function useTimesheetEntryCalculations(companyDefaults: Ref<CompanyDefaul
       _isSaving: false,
       isNewRow: false,
       isModified: false,
+      // Include staff wage rate for consistent grid calculations
+      wageRate: staffWageRate,
+      staffId: staffId,
+      staffName: staffData?.name || '',
+      date: metaObj && 'date' in metaObj && typeof metaObj.date === 'string' ? metaObj.date : '',
+      hours: hours,
+      description: costLine.desc || '',
+      rate: rateType,
+      wage: calculatedWage, // ✅ ALWAYS use calculated wage
+      bill: costLine.total_rev || 0,
+      billable: metaObj && 'is_billable' in metaObj ? Boolean(metaObj.is_billable) : true,
+      chargeOutRate: parseFloat(costLine.unit_rev || '0'),
+      rateMultiplier: backendRateMultiplier,
     }
   }
 

--- a/src/composables/useTimesheetEntryGrid.ts
+++ b/src/composables/useTimesheetEntryGrid.ts
@@ -370,10 +370,14 @@ export function useTimesheetEntryGrid(
     const rateMultiplier = calculations.getRateMultiplier(rate)
     const billable = rowData.billable ?? true
 
-    const calculatedWage =
-      hours > 0 && wageRate > 0 ? Math.round(hours * rateMultiplier * wageRate * 100) / 100 : 0
-    const calculatedBill =
-      billable && hours > 0 && chargeOutRate > 0 ? Math.round(hours * chargeOutRate * 100) / 100 : 0
+    let calculatedWage = 0
+    if (hours > 0 && wageRate > 0)
+      calculatedWage = Math.round(hours * rateMultiplier * wageRate * 100) / 100
+
+    let calculatedBill = 0
+    if (billable && hours > 0 && chargeOutRate > 0) {
+      calculatedBill = Math.round(hours * chargeOutRate * 100) / 100
+    }
 
     console.log('🧮 Grid wage calculation:', {
       hours,

--- a/src/composables/useTimesheetEntryGrid.ts
+++ b/src/composables/useTimesheetEntryGrid.ts
@@ -370,7 +370,6 @@ export function useTimesheetEntryGrid(
     const rateMultiplier = calculations.getRateMultiplier(rate)
     const billable = rowData.billable ?? true
 
-    // ✅ CORRECT WAGE CALCULATION: hours × rate_multiplier × staff_wage_rate
     const calculatedWage =
       hours > 0 && wageRate > 0 ? Math.round(hours * rateMultiplier * wageRate * 100) / 100 : 0
     const calculatedBill =

--- a/src/constants/timesheet.ts
+++ b/src/constants/timesheet.ts
@@ -5,7 +5,7 @@
  */
 
 import { z } from 'zod'
-import { schemas } from '@/api/generated/schemas'
+import { schemas } from '@/api/generated/api'
 
 /**
  * Schema for timesheet entry metadata (UI-specific extension of backend schema).
@@ -20,6 +20,6 @@ export const TimesheetEntryWithMetaSchema = schemas.TimesheetCostLine.extend({
 export type TimesheetEntryWithMeta = z.infer<typeof TimesheetEntryWithMetaSchema>
 
 export type TimesheetEntryJobSelectionItem = Pick<
-  z.infer<typeof schemas.Job>,
+  z.infer<typeof schemas.ModernTimesheetJob>,
   'id' | 'job_number' | 'name' | 'client_name' | 'status' | 'charge_out_rate'
 >

--- a/src/services/job.service.ts
+++ b/src/services/job.service.ts
@@ -3,6 +3,7 @@ import { api } from '../api/client'
 import axios from '../plugins/axios'
 import { z } from 'zod'
 import { AdvancedFilters } from '../constants/advanced-filters'
+import { AxiosError } from 'axios'
 
 type AdvancedSearchResponse = z.infer<typeof schemas.AdvancedSearchResponse>
 type KanbanJob = z.infer<typeof schemas.KanbanJob>
@@ -79,10 +80,21 @@ export const jobService = {
         success: response.success,
         message: response.message,
       }))
-      .catch((error: Error) => ({
-        success: false,
-        error: error.message || 'Failed to delete job',
-      }))
+      .catch((error: unknown) => {
+        console.error('[deleteJob] erro ao deletar job', error)
+
+        let msg = 'Failed to delete job'
+
+        if ((error as AxiosError).isAxiosError) {
+          const axiosErr = error as AxiosError<{ error: string }>
+          msg = axiosErr.response?.data?.error ?? msg
+        }
+
+        return {
+          success: false,
+          error: msg,
+        }
+      })
   },
 
   // Archive

--- a/src/services/timesheet.service.ts
+++ b/src/services/timesheet.service.ts
@@ -11,7 +11,9 @@ type CostLine = z.infer<typeof schemas.CostLine>
 export class TimesheetService {
   static async getStaff(): Promise<Staff[]> {
     try {
-      const staff = await api.timesheets_api_staff_retrieve()
+      // Mount date parameter to send to API in format YYYY-MM-DD
+      const date_param = new Date().toISOString().substring(0, 10)
+      const staff = await api.timesheets_api_staff_retrieve({ queries: date_param })
 
       // Get company defaults for fallback wage rate
       let defaultWageRate = 32

--- a/src/services/weekly-timesheet.service.ts
+++ b/src/services/weekly-timesheet.service.ts
@@ -76,16 +76,34 @@ export function formatDateRange(startDate: string, endDate: string): string {
 
 /**
  * Format hours with one decimal.
+ * Handles both number and string inputs from the API.
  */
-export function formatHours(hours: number): string {
-  return hours.toFixed(1)
+export function formatHours(hours: number | string): string {
+  const numericHours = typeof hours === 'string' ? parseFloat(hours) : hours
+
+  // Handle invalid values
+  if (isNaN(numericHours)) {
+    console.warn('formatHours received invalid value:', hours)
+    return '0.0'
+  }
+
+  return numericHours.toFixed(1)
 }
 
 /**
  * Format a percentage with one decimal.
+ * Handles both number and string inputs from the API.
  */
-export function formatPercentage(percentage: number): string {
-  return `${percentage.toFixed(1)}%`
+export function formatPercentage(percentage: number | string): string {
+  const numericPercentage = typeof percentage === 'string' ? parseFloat(percentage) : percentage
+
+  // Handle invalid values
+  if (isNaN(numericPercentage)) {
+    console.warn('formatPercentage received invalid value:', percentage)
+    return '0.0%'
+  }
+
+  return `${numericPercentage.toFixed(1)}%`
 }
 
 export default {

--- a/src/views/JobCreateView.vue
+++ b/src/views/JobCreateView.vue
@@ -478,7 +478,7 @@ const handleSubmit = async () => {
           unit_cost: formData.value.estimatedMaterials!.toFixed(2),
           unit_rev: (
             formData.value.estimatedMaterials! *
-            (1 + (companyDefaultsStore.companyDefaults?.materials_markup ?? 0))
+            (1 + Number(companyDefaultsStore.companyDefaults?.materials_markup ?? 0))
           ).toFixed(2),
         })
       } catch (error: unknown) {

--- a/src/views/JobView.vue
+++ b/src/views/JobView.vue
@@ -356,6 +356,7 @@ async function deleteJob() {
       notifications.notifyDeleteSuccess(jobName)
       navigateBack()
     } else {
+      debugLog('Detected error in response: ', result)
       throw new Error(result.error || 'Failed to delete job')
     }
   } catch (err: unknown) {

--- a/src/views/TimesheetEntryView.vue
+++ b/src/views/TimesheetEntryView.vue
@@ -984,7 +984,6 @@ const saveChanges = async () => {
         rateMultiplier = 1.0
     }
 
-    // ✅ CORRECT WAGE CALCULATION: hours × rate_multiplier × staff_wage_rate
     const calculatedWage =
       hours > 0 && wageRate > 0 ? Math.round(hours * rateMultiplier * wageRate * 100) / 100 : 0
     const calculatedBill =

--- a/src/views/TimesheetEntryView.vue
+++ b/src/views/TimesheetEntryView.vue
@@ -1031,6 +1031,7 @@ const saveChanges = async () => {
   }
 
   hasUnsavedChanges.value = false
+  reloadData()
 }
 
 const reloadData = () => {

--- a/src/views/TimesheetEntryView.vue
+++ b/src/views/TimesheetEntryView.vue
@@ -984,10 +984,14 @@ const saveChanges = async () => {
         rateMultiplier = 1.0
     }
 
-    const calculatedWage =
-      hours > 0 && wageRate > 0 ? Math.round(hours * rateMultiplier * wageRate * 100) / 100 : 0
-    const calculatedBill =
-      billable && hours > 0 && chargeOutRate > 0 ? Math.round(hours * chargeOutRate * 100) / 100 : 0
+    let calculatedWage = 0
+    if (hours > 0 && wageRate > 0)
+      calculatedWage = Math.round(hours * rateMultiplier * wageRate * 100) / 100
+
+    let calculatedBill = 0
+    if (billable && hours > 0 && chargeOutRate > 0) {
+      calculatedBill = Math.round(hours * chargeOutRate * 100) / 100
+    }
 
     debugLog('🧮 Recalculated entry with correct formula:', {
       id: entry.id,

--- a/src/views/TimesheetEntryView.vue
+++ b/src/views/TimesheetEntryView.vue
@@ -442,6 +442,7 @@ import { useRouter, useRoute } from 'vue-router'
 import { AgGridVue } from 'ag-grid-vue3'
 import type { GridReadyEvent, CellValueChangedEvent } from 'ag-grid-community'
 import { v4 as uuidv4 } from 'uuid'
+import { debounce } from 'lodash-es'
 
 import AppLayout from '@/components/AppLayout.vue'
 import { Button } from '@/components/ui/button'
@@ -500,6 +501,7 @@ debugLog('📊 Using initial values:', { date: initialDate, staffId: initialStaf
 const currentDate = ref<string>(initialDate)
 const selectedStaffId = ref<string>(initialStaffId)
 const isInitializing = ref(true)
+const isLoadingData = ref(false) // ✅ Add loading flag to prevent duplicate calls
 
 const timeEntries = ref<TimesheetEntryWithMeta[]>([])
 
@@ -524,6 +526,8 @@ const todayStats = computed(() => {
   }
 })
 
+const companyDefaultsRef = computed(() => companyDefaultsStore.companyDefaults)
+
 const {
   gridData,
   columnDefs,
@@ -535,7 +539,7 @@ const {
   handleKeyboardShortcut,
   handleCellValueChanged: gridHandleCellValueChanged,
 } = useTimesheetEntryGrid(
-  companyDefaultsStore.companyDefaults,
+  companyDefaultsRef,
   timesheetStore.jobs, // Pass jobs from timesheet store
   handleSaveEntry,
   handleDeleteEntry,
@@ -677,6 +681,7 @@ function syncGridState() {
       hours: d.hours,
       isEmptyRow: d.isEmptyRow,
       isNewRow: d.isNewRow,
+      isModified: d.isModified, // ✅ Include modification status
     })),
   )
 
@@ -686,6 +691,7 @@ function syncGridState() {
       jobId: d?.jobId,
       jobNumber: d?.jobNumber,
       isEmptyRow: d?.isEmptyRow,
+      isModified: d?.isModified, // ✅ Log modification status
       hasJob,
     })
     return hasJob
@@ -701,8 +707,8 @@ function syncGridState() {
 
     return {
       ...gridEntry,
-      isModified: existingEntry?.isModified || gridEntry.isModified || false,
-      isNewRow: existingEntry?.isNewRow || gridEntry.isNewRow || false,
+      isModified: gridEntry.isModified || existingEntry?.isModified || false, // ✅ Prioritize grid state
+      isNewRow: gridEntry.isNewRow || existingEntry?.isNewRow || false,
     } as CostLine
   })
 
@@ -718,6 +724,7 @@ function syncGridState() {
       client: e.client,
       jobName: e.jobName,
       hours: e.hours,
+      isModified: e.isModified, // ✅ Log modification status
     })),
   )
 }
@@ -797,9 +804,12 @@ async function handleSaveEntry(entry: TimesheetEntryWithMeta): Promise<void> {
     }
 
     let savedLine
-    if (entry.id && typeof entry.id === 'number') {
+    // ✅ FIXED: Always check for existing ID first, including string IDs
+    if (entry.id && (typeof entry.id === 'number' || typeof entry.id === 'string')) {
+      debugLog('🔄 UPDATING existing entry:', entry.id)
       savedLine = await costlineService.updateCostLine(entry.id, costLinePayload)
     } else {
+      debugLog('➕ CREATING new entry')
       const job = timesheetStore.jobs.find((j: Job) => j.id === targetJobId)
       if (!job) throw new Error('Job not found')
       savedLine = await costlineService.createCostLine(job.id, 'actual', costLinePayload)
@@ -875,8 +885,21 @@ function onFirstDataRendered() {
 const addNewEntry = () => {
   debugLog('➕ Adding new entry for staff:', selectedStaffId.value)
 
+  const staffData = timesheetStore.staff.find((s) => s.id === selectedStaffId.value)
+
+  debugLog('👤 Staff data for new entry:', {
+    staffId: selectedStaffId.value,
+    staffData: staffData
+      ? {
+          id: staffData.id,
+          name: `${staffData.firstName} ${staffData.lastName}`,
+          wageRate: staffData.wageRate,
+        }
+      : null,
+  })
+
   // Use the composable's addNewRow function which properly handles ag-Grid
-  addNewRow(selectedStaffId.value, currentDate.value)
+  addNewRow(selectedStaffId.value, currentDate.value, staffData)
 
   hasUnsavedChanges.value = true
 
@@ -891,7 +914,7 @@ const saveChanges = async () => {
   syncGridState()
 
   const changedEntries = timeEntries.value.filter(
-    (entry: CostLine) => entry.isNewRow || entry.isModified,
+    (entry: CostLine) => entry.isModified || entry.isNewRow,
   )
 
   debugLog('📊 Found', changedEntries.length, 'changed entries to save')
@@ -935,18 +958,76 @@ const saveChanges = async () => {
     return
   }
 
-  for (const entry of changedEntries) {
-    debugLog('🔄 Saving entry:', {
+  const recalculatedEntries = changedEntries.map((entry) => {
+    const hours = typeof entry.hours === 'string' ? parseFloat(entry.hours) || 0 : entry.hours || 0
+    const wageRate =
+      typeof entry.wageRate === 'string' ? parseFloat(entry.wageRate) || 0 : entry.wageRate || 0
+    const chargeOutRate =
+      typeof entry.chargeOutRate === 'string'
+        ? parseFloat(entry.chargeOutRate) || 0
+        : entry.chargeOutRate || 0
+    const rate = entry.rate || 'Ord'
+    const billable = entry.billable ?? true
+
+    let rateMultiplier = 1.0
+    switch (rate) {
+      case '1.5':
+        rateMultiplier = 1.5
+        break
+      case '2.0':
+        rateMultiplier = 2.0
+        break
+      case 'Unpaid':
+        rateMultiplier = 0.0
+        break
+      default:
+        rateMultiplier = 1.0
+    }
+
+    // ✅ CORRECT WAGE CALCULATION: hours × rate_multiplier × staff_wage_rate
+    const calculatedWage =
+      hours > 0 && wageRate > 0 ? Math.round(hours * rateMultiplier * wageRate * 100) / 100 : 0
+    const calculatedBill =
+      billable && hours > 0 && chargeOutRate > 0 ? Math.round(hours * chargeOutRate * 100) / 100 : 0
+
+    debugLog('🧮 Recalculated entry with correct formula:', {
+      id: entry.id,
+      hours,
+      wageRate,
+      chargeOutRate,
+      rate,
+      rateMultiplier,
+      billable,
+      calculatedWage,
+      calculatedBill,
+      formula: `${hours} × ${rateMultiplier} × ${wageRate} = ${calculatedWage}`,
+    })
+
+    return {
+      ...entry,
+      hours,
+      wageRate,
+      chargeOutRate,
+      rateMultiplier,
+      wage: calculatedWage,
+      bill: calculatedBill,
+    }
+  })
+
+  for (const entry of recalculatedEntries) {
+    debugLog('🔄 Saving recalculated entry:', {
       id: entry.id,
       isNewRow: entry.isNewRow,
       isModified: entry.isModified,
       description: entry.description,
+      wage: entry.wage,
+      bill: entry.bill,
     })
-    debugLog('Call-stack: ', new Error().stack)
-    debugLog('Timestamp:', new Date().toISOString())
     await handleSaveEntry(entry)
 
+    // ✅ Mark as saved and update grid state
     entry.isModified = false
+    entry.isNewRow = false
   }
 
   hasUnsavedChanges.value = false
@@ -977,7 +1058,8 @@ const handleStaffChange = async (staffId: string | null) => {
   selectedStaffId.value = staffId
   updateRoute()
 
-  await loadTimesheetData()
+  // ✅ Use debounced version and don't await to prevent blocking UI
+  debouncedLoadTimesheetData()
 }
 
 const loadTimesheetData = async () => {
@@ -985,10 +1067,17 @@ const loadTimesheetData = async () => {
     staffId: selectedStaffId.value,
     date: currentDate.value,
     isInitializing: isInitializing.value,
+    isLoadingData: isLoadingData.value,
   })
 
   debugLog('Call-stack: ', new Error().stack)
   debugLog('Timestamp:', new Date().toISOString())
+
+  // ✅ Prevent duplicate calls
+  if (isLoadingData.value) {
+    debugLog('⏭️ Skipping data load - already loading')
+    return
+  }
 
   if (!selectedStaffId.value) {
     debugLog('⏭️ Skipping data load - no staff selected')
@@ -1002,6 +1091,7 @@ const loadTimesheetData = async () => {
 
   try {
     loading.value = true
+    isLoadingData.value = true // ✅ Set loading flag
     error.value = null
 
     debugLog('📊 Loading timesheet data for:', {
@@ -1018,31 +1108,52 @@ const loadTimesheetData = async () => {
     debugLog('📄 Cost lines from API:', response.cost_lines)
     debugLog('📊 Number of cost lines:', response.cost_lines?.length || 0)
 
-    timeEntries.value = response.cost_lines.map((line: TimesheetCostLine) => ({
-      id: line.id,
-      jobId: line.job_id || '',
-      jobNumber: line.job_number || '',
-      client: line.client_name || '',
-      jobName: line.job_name || '',
-      hours: parseFloat(line.quantity),
-      billable: typeof line.meta?.is_billable === 'boolean' ? line.meta.is_billable : true,
-      description: line.desc,
-      rate: getRateTypeFromMultiplier(
-        typeof line.meta?.rate_multiplier === 'number' ? line.meta.rate_multiplier : 1.0,
-      ),
-      wage: line.wage_rate || parseFloat(line.unit_cost), // Wage per hour (staff cost)
-      bill: line.total_rev,
-      staffId: selectedStaffId.value,
-      date: currentDate.value,
-      wageRate: line.wage_rate || parseFloat(line.unit_cost),
-      chargeOutRate: parseFloat(line.charge_out_rate),
-      rateMultiplier:
-        typeof line.meta?.rate_multiplier === 'number' ? line.meta.rate_multiplier : 1.0,
-      isNewRow: false,
-      isModified: false,
-    }))
+    timeEntries.value = response.cost_lines.map((line: TimesheetCostLine) => {
+      const hours = parseFloat(line.quantity)
+      const staffWageRate = line.wage_rate || parseFloat(line.unit_cost)
+      const rateMultiplier =
+        typeof line.meta?.rate_multiplier === 'number' ? line.meta.rate_multiplier : 1.0
 
-    loadData(timeEntries.value, selectedStaffId.value)
+      // ✅ ALWAYS CALCULATE WAGE WITH CORRECT FORMULA: hours × rate_multiplier × staff_wage_rate
+      const calculatedWage =
+        hours > 0 && staffWageRate > 0
+          ? Math.round(hours * rateMultiplier * staffWageRate * 100) / 100
+          : 0
+
+      debugLog('📊 Loading entry with correct wage calculation:', {
+        id: line.id,
+        hours,
+        staffWageRate,
+        rateMultiplier,
+        calculatedWage,
+        backendWage: line.total_cost,
+        formula: `${hours} × ${rateMultiplier} × ${staffWageRate} = ${calculatedWage}`,
+      })
+
+      return {
+        id: line.id,
+        jobId: line.job_id || '',
+        jobNumber: line.job_number || '',
+        client: line.client_name || '',
+        jobName: line.job_name || '',
+        hours,
+        billable: typeof line.meta?.is_billable === 'boolean' ? line.meta.is_billable : true,
+        description: line.desc,
+        rate: getRateTypeFromMultiplier(rateMultiplier),
+        wage: calculatedWage, // ✅ ALWAYS use calculated wage
+        bill: line.total_rev,
+        staffId: selectedStaffId.value,
+        date: currentDate.value,
+        wageRate: staffWageRate,
+        chargeOutRate: parseFloat(line.charge_out_rate),
+        rateMultiplier,
+        isNewRow: false,
+        isModified: false,
+      }
+    })
+
+    const staffData = timesheetStore.staff.find((s) => s.id === selectedStaffId.value)
+    loadData(timeEntries.value, selectedStaffId.value, staffData)
 
     debugLog(`✅ Loaded ${timeEntries.value.length} timesheet entries`)
   } catch (err) {
@@ -1050,8 +1161,12 @@ const loadTimesheetData = async () => {
     error.value = 'Failed to load timesheet data'
   } finally {
     loading.value = false
+    isLoadingData.value = false // ✅ Clear loading flag
   }
 }
+
+// ✅ Create debounced version to prevent rapid successive calls
+const debouncedLoadTimesheetData = debounce(loadTimesheetData, 300)
 
 const getRateTypeFromMultiplier = (multiplier: number): string => {
   switch (multiplier) {
@@ -1074,7 +1189,8 @@ const handleKeydown = (event: KeyboardEvent) => {
     return
   }
 
-  if (handleKeyboardShortcut(event, selectedStaffId.value)) {
+  const staffData = timesheetStore.staff.find((s) => s.id === selectedStaffId.value)
+  if (handleKeyboardShortcut(event, selectedStaffId.value, staffData)) {
     return
   }
 
@@ -1111,6 +1227,7 @@ onMounted(async () => {
     await timesheetStore.loadStaff()
     await timesheetStore.loadJobs()
     await companyDefaultsStore.loadCompanyDefaults()
+    debugLog('Company Defaults store value: ', companyDefaultsStore.companyDefaults)
 
     let validStaffId = selectedStaffId.value
 
@@ -1183,7 +1300,8 @@ watch(
       oldStaffId,
       oldDate,
     })
-    await loadTimesheetData()
+    // ✅ Use debounced version to prevent rapid calls
+    debouncedLoadTimesheetData()
   },
   { immediate: false },
 )
@@ -1219,7 +1337,8 @@ watch(
 
     if (hasChanges) {
       debugLog('🔄 Reloading data due to URL changes')
-      loadTimesheetData()
+      // ✅ Use debounced version to prevent rapid calls
+      debouncedLoadTimesheetData()
     }
   },
   { immediate: false },

--- a/src/views/WeeklyTimesheetView.vue
+++ b/src/views/WeeklyTimesheetView.vue
@@ -238,6 +238,7 @@ import {
 } from '@/services/date.service'
 import { fetchWeeklyOverview, fetchIMSOverview } from '@/services/weekly-timesheet.service'
 import type { WeeklyTimesheetData, IMSWeeklyTimesheetData } from '@/api/generated/api'
+import { debugLog } from '../utils/debug'
 
 const loading = ref(false)
 const error = ref<string | null>(null)
@@ -295,6 +296,7 @@ async function loadData(): Promise<void> {
     error.value =
       'Failed to load weekly timesheet data. Please try again. ' +
       (err instanceof Error ? err.message : 'Unknown error')
+    debugLog('Error while loading weekly timsheet data: ', err)
   } finally {
     loading.value = false
   }


### PR DESCRIPTION
feat: sync schema → code, refine wage calc, and harden timesheet UX

### OpenAPI / Generated Types
* **schema.yml**
  * Add `date` query-param to `/timesheets/staff/`
  * Mark various fields `nullable`, rename `id` → `staff_id`, `date` → `day`
  * Enrich weekly staff/hour objects with billable + scheduling fields
  * Add `unit_cost` / `unit_rev` to `StockConsumeRequest`
* Regenerate `src/api/generated/api.ts`
  * Mirrors all schema tweaks (nullables, new props, removed `week_start`)
  * Adds parameter spec for `timesheets_api_staff_retrieve`

### Front-end changes summary
* **JobActualTab.vue**
  * Uses typed `StockConsumeRequest`; after consume, reloads cost lines
* **StockConsumptionModal.vue**
  * Client-side max-qty guard, zero-qty filter, better UX validation
* **BillablePercentageBadge.vue**
  * Accepts string|number; robust parsing & color logic
* **TimesheetEntry grid/composables**
  * **Correct formula everywhere:** `hours × rate_multiplier × staff_wage_rate`
  * Wage/bill recalculated on edit & before save
  * Disable autosave; entries flagged `isModified`, bulk “Save All” now reconciles
  * Prevent dup rows, honour staff wage rate, debounce data loads
  * Extra keyboard shortcuts use real staff data
* **Services**
  * Staff fetch supplies `date` query
  * Weekly metrics endpoint rename; robust Axios error handling on job delete / invoice create
* **WeeklyTimesheetView.vue**
  * Debug logging & error surfacing
* Misc clean-ups:
  * Remove legacy `week_start`
  * Switch constants import to generated `api` schema
  * Materials markup calc cast to `Number` for safety

### Why
Brings API contract and Vue code back in lock-step, fixes under-billing caused by mis-applied wage formula, and tightens edge-case handling across timesheet flows, stock consumption, and financial ops.

