### PR TITLE
fix(schema): update to support nullable xero_quote field

### DIFF
--- a/schema.yml
+++ b/schema.yml
@@ -6645,6 +6645,7 @@ components:
         xero_quote:
           allOf:
             - $ref: '#/components/schemas/XeroQuote'
+          nullable: true
           readOnly: true
         xero_invoices:
           type: array

--- a/src/api/generated/api.ts
+++ b/src/api/generated/api.ts
@@ -867,7 +867,7 @@ const Job = z
     fully_invoiced: z.boolean(),
     quote: z.object({}).partial().passthrough().nullable(),
     invoice: z.object({}).partial().passthrough().nullable(),
-    xero_quote: XeroQuote,
+    xero_quote: XeroQuote.nullable(),
     xero_invoices: z.array(XeroInvoice),
     shop_job: z.boolean(),
   })


### PR DESCRIPTION
- Regenerate API schema with xero_quote as nullable
- Fixes Zod validation error when xero_quote is null
- Allows job pages to load when no Xero quote exists

🤖 Generated with [Claude Code](https://claude.ai/code)

## 📝 Description

_Short explanation of what you’ve built and why._

## 🔗 Related Issue

Closes #[issue-number]

## 🚀 Changes

- Bullet-list of feature additions or fixes (e.g. extracted `useChat` composable, split `ChatHistory` and `ChatInput` components, added Pinia store).
- …

## ✅ Checklist

**Vue.js (Composition API)**

- [ ] Used Composition API (`<script setup>` & composables), no heavy logic in templates
- [ ] UI logic extracted to reusable composables (`useChat`, etc.)
- [ ] Components are focused & small (<200 LOC)
- [ ] Communication via `props` and `emit`, no direct parent/child ref duplication
- [ ] State management in Pinia; no ad-hoc reactive globals
- [ ] Routes/components lazy-loaded where appropriate

**Quality & Formatting**

- [ ] Passes Prettier (`npx prettier --check .`)
- [ ] Passes ESLint with zero warnings (`npx eslint . --ext .js,.ts,.vue`)
- [ ] Added JSDoc comments for all props and emitted events
- [ ] New or updated unit/E2E tests included
