### PR TITLE
refactor(JobCreateView.vue): move ClientLookup component to the top o…

### DIFF
--- a/src/components/ClientLookup.vue
+++ b/src/components/ClientLookup.vue
@@ -46,7 +46,7 @@
           >
             <div class="flex items-center">
               <Plus class="w-4 h-4 mr-2" />
-              Add new {{ supplierLookup ? 'supplier' : 'client' }} "{{ searchQuery }}"
+              Add new client "{{ searchQuery }}"
             </div>
           </div>
 

--- a/src/views/JobCreateView.vue
+++ b/src/views/JobCreateView.vue
@@ -11,6 +11,21 @@
             <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
               <div class="space-y-6">
                 <div>
+                  <ClientLookup
+                    id="client"
+                    v-model="formData.client_name as string"
+                    @update:selected-id="formData.client_id = $event"
+                    @update:selected-client="handleClientSelection"
+                    label="Client"
+                    :required="true"
+                    placeholder="Search for a client..."
+                  />
+                  <p v-if="errors.client_id" class="mt-1 text-sm text-red-600">
+                    {{ errors.client_id }}
+                  </p>
+                </div>
+
+                <div>
                   <label
                     for="name"
                     class="block text-sm font-medium mb-2"
@@ -35,21 +50,6 @@
                   />
                   <p v-if="errors.name" class="mt-1 text-sm text-red-600">
                     {{ errors.name }}
-                  </p>
-                </div>
-
-                <div>
-                  <ClientLookup
-                    id="client"
-                    v-model="formData.client_name as string"
-                    @update:selected-id="formData.client_id = $event"
-                    @update:selected-client="handleClientSelection"
-                    label="Client"
-                    :required="true"
-                    placeholder="Search for a client..."
-                  />
-                  <p v-if="errors.client_id" class="mt-1 text-sm text-red-600">
-                    {{ errors.client_id }}
                   </p>
                 </div>
 


### PR DESCRIPTION
…f the form

fix(ClientLookup.vue): remove conditional text for adding new client/supplier

The `ClientLookup` component is now positioned at the top of the form in `JobCreateView.vue` to improve the logical flow and user experience when creating a new job. The conditional text for "supplier" has been removed from `ClientLookup.vue` because this component is specifically designed for client lookups, simplifying its purpose and preventing potential confusion.