### PR TITLE
Refactor: merge actual and financial tabs

### DIFF
--- a/.kilocode/tasks/merge-actual-financial-tabs.md
+++ b/.kilocode/tasks/merge-actual-financial-tabs.md
@@ -1,0 +1,305 @@
+# Financial Tabs Migration Plan
+
+## Overview
+
+This plan outlines the migration of financial information from `JobFinancialTab.vue` to `JobActualTab.vue`, including the creation of a centralised composable for financial data management and the relocation of quote functionality to `JobQuoteTab.vue`.
+
+## Requirements
+
+### Functional Requirements
+
+1. **Financial Cards Migration**
+
+   - Move estimate, time & expenses, invoiced, and to be invoiced cards from `JobFinancialTab.vue` to `JobActualTab.vue`
+   - Cards should be smaller and positioned in the available space next to Actual Costs
+   - Maintain all existing functionality and calculations
+
+2. **Invoices Management**
+
+   - Move invoices list and create invoice button from `JobFinancialTab.vue` to `JobActualTab.vue`
+   - Position invoices grid below the Actual Summary section
+   - Preserve all Xero integration functionality
+
+3. **Composable Creation**
+
+   - Create `useFinances` composable to centralise financial data management
+   - Include quote operations and invoice management
+   - Provide reactive state for all financial metrics
+
+4. **Quote Grid Relocation**
+
+   - Move quote grid from `JobFinancialTab.vue` to `JobQuoteTab.vue`
+   - Ensure all quote operations remain functional
+
+5. **Print Shortcuts Addition**
+
+   - Add print and download sheet buttons to `JobQuoteTab.vue`
+   - Reuse existing print functionality from `JobPdfTab.vue`
+   - Maintain consistent UI/UX
+
+6. **Xero Operations Preservation**
+   - All quote and invoice Xero operations must remain unchanged
+   - Ensure backward compatibility with existing workflows
+
+### Technical Requirements
+
+- Maintain TypeScript type safety throughout
+- Preserve all existing API integrations
+- Ensure responsive design on all screen sizes
+- Follow established architectural patterns
+- No breaking changes to existing functionality
+
+## Architecture
+
+### Composable Design (`useFinances`)
+
+```typescript
+interface UseFinancesReturn {
+  // Financial metrics
+  estimateTotal: ComputedRef<number>
+  timeAndExpenses: ComputedRef<number>
+  invoiceTotal: ComputedRef<number>
+  toBeInvoiced: ComputedRef<number>
+  quoteTotal: ComputedRef<number>
+
+  // Invoice management
+  invoices: Ref<Invoice[]>
+  isCreatingInvoice: Ref<boolean>
+  deletingInvoiceId: Ref<string | null>
+
+  // Quote operations
+  isQuoteDeleted: Ref<boolean>
+  isDeletingQuote: Ref<boolean>
+  isCreatingQuote: Ref<boolean>
+  isAcceptingQuote: Ref<boolean>
+  quoteUrl: ComputedRef<string | null>
+
+  // Actions
+  createQuote: () => Promise<void>
+  acceptQuote: () => Promise<void>
+  deleteQuoteOnXero: () => Promise<void>
+  goToQuoteOnXero: () => void
+
+  createInvoice: () => Promise<void>
+  goToInvoiceOnXero: (url: string) => void
+  deleteInvoiceOnXero: (invoiceId: string) => Promise<void>
+
+  // Formatting
+  formatCurrency: (amount: number) => string
+  formatDate: (date: string) => string
+}
+```
+
+### Component Structure
+
+#### JobActualTab.vue (After Migration)
+
+```
+┌─────────────────────────────────────┐
+│ Header: Actual Costs                │
+│ [Actual Cost Dropdown]              │
+├─────────────────────────────────────┤
+│ ┌─────────────┬─────────────────────┐ │
+│ │ Cost Lines  │ Financial Cards     │ │
+│ │ Grid        │ (Estimate, Time &   │ │
+│ │             │ Expenses, Invoiced, │ │
+│ │             │ To Be Invoiced)     │ │
+│ └─────────────┴─────────────────────┘ │
+├─────────────────────────────────────┤
+│ Actual Summary                       │
+├─────────────────────────────────────┤
+│ Invoices Grid                        │
+│ [Create Invoice Button]              │
+└─────────────────────────────────────┘
+```
+
+#### JobQuoteTab.vue (After Migration)
+
+```
+┌─────────────────────────────────────┐
+│ Header: Quote Management            │
+│ [Buttons: Copy from Estimate,       │
+│  Quote Revisions, Link Spreadsheet, │
+│  Refresh, Print, Download]          │
+├─────────────────────────────────────┤
+│ Quote Details Grid                  │
+├─────────────────────────────────────┤
+│ Quote Summary                       │
+└─────────────────────────────────────┘
+```
+
+## Implementation Tasks
+
+### Phase 1: Composable Creation
+
+1. **Create `useFinances` Composable**
+
+   - Extract financial calculations from `JobFinancialTab.vue`
+   - Implement reactive state management
+   - Add quote and invoice operations
+   - Include proper error handling
+
+2. **Test Composable Integration**
+   - Verify all calculations work correctly
+   - Test Xero API integrations
+   - Ensure proper reactivity
+
+### Phase 2: JobActualTab Migration
+
+3. **Add Financial Cards to JobActualTab**
+
+   - Import and integrate financial cards
+   - Position cards in available space
+   - Adjust card sizes for compact layout
+   - Connect to `useFinances` composable
+
+4. **Add Invoices Section to JobActualTab**
+
+   - Move invoices grid below Actual Summary
+   - Integrate create invoice functionality
+   - Connect to `useFinances` composable
+
+5. **Update JobActualTab Layout**
+   - Adjust grid layout to accommodate new sections
+   - Ensure responsive design
+   - Test on different screen sizes
+
+### Phase 3: JobQuoteTab Enhancement
+
+6. **Move Quote Grid to JobQuoteTab**
+
+   - Extract quote grid from `JobFinancialTab.vue`
+   - Integrate into `JobQuoteTab.vue`
+   - Connect to `useFinances` composable
+
+7. **Add Print Shortcuts to JobQuoteTab**
+   - Import print/download functionality from `JobPdfTab.vue`
+   - Add buttons to header section
+   - Ensure proper integration with job data
+
+### Phase 4: Cleanup and Testing
+
+8. **Update JobFinancialTab References**
+
+   - Remove financial cards and invoices from `JobFinancialTab.vue`
+   - Keep only quote section temporarily
+   - Update any component references
+
+9. **Remove JobFinancialTab Completely**
+
+   - Delete `JobFinancialTab.vue` file
+   - Update routing and navigation
+   - Clean up any remaining references
+
+10. **Comprehensive Testing**
+    - Test all financial calculations
+    - Verify Xero integrations work
+    - Test print functionality
+    - Ensure no regressions
+
+## Dependencies
+
+### External Dependencies
+
+- Xero API integration (must remain functional)
+- Vue 3 Composition API
+- Existing UI components (Button, Card, Table, etc.)
+- Job data structure from API
+
+### Internal Dependencies
+
+- `JobActualTab.vue` current layout
+- `JobQuoteTab.vue` current structure
+- `JobPdfTab.vue` print functionality
+- Existing composables and services
+
+## Risk Assessment
+
+### High Risk
+
+- Xero API integration breakage
+- Financial calculation errors
+- Loss of existing functionality
+
+### Medium Risk
+
+- Layout and responsive design issues
+- Print functionality integration problems
+- Component state management conflicts
+
+### Low Risk
+
+- Composable creation and testing
+- UI component styling adjustments
+- File cleanup and reference updates
+
+## Success Criteria
+
+1. All financial cards display correctly in `JobActualTab.vue`
+2. Invoices list and creation work in `JobActualTab.vue`
+3. Quote grid functions in `JobQuoteTab.vue`
+4. Print shortcuts work in `JobQuoteTab.vue`
+5. All Xero operations remain functional
+6. No breaking changes to existing workflows
+7. Responsive design maintained
+8. TypeScript compilation successful
+9. All tests pass
+
+## Rollback Plan
+
+If issues arise during implementation:
+
+1. **Composable Issues**: Revert to direct component logic
+2. **Layout Problems**: Restore original component structures
+3. **Xero Integration**: Verify API endpoints and authentication
+4. **Print Functionality**: Use original `JobPdfTab.vue` as fallback
+
+## Timeline
+
+- **Phase 1**: 2-3 days (Composable creation and testing)
+- **Phase 2**: 3-4 days (JobActualTab migration)
+- **Phase 3**: 2-3 days (JobQuoteTab enhancement)
+- **Phase 4**: 1-2 days (Cleanup and testing)
+
+Total estimated time: 8-12 days
+
+## Testing Strategy
+
+### Unit Tests
+
+- Test `useFinances` composable calculations
+- Test component integrations
+- Test Xero API calls
+
+### Integration Tests
+
+- Test financial data flow between components
+- Test print functionality integration
+- Test responsive layout
+
+### End-to-End Tests
+
+- Test complete user workflows
+- Test Xero integration end-to-end
+- Test on different devices and browsers
+
+## Documentation Updates
+
+1. Update component documentation
+2. Update API integration docs
+3. Add composable usage examples
+4. Update testing documentation
+
+## Communication Plan
+
+1. **Team Notification**: Inform team of planned changes
+2. **Progress Updates**: Regular status updates during implementation
+3. **Testing Coordination**: Coordinate testing with QA team
+4. **Deployment Planning**: Plan deployment and monitoring
+
+---
+
+**Document Version**: 1.0
+**Date**: September 2025
+**Author**: Kilo Code AI
+**Status**: Ready for Implementation

--- a/src/components/job/JobViewTabs.vue
+++ b/src/components/job/JobViewTabs.vue
@@ -61,8 +61,14 @@
         <JobActualTab
           v-if="jobData"
           :job-id="jobData.id"
+          :job-data="jobData"
           :actual-summary-from-backend="jobData.latest_actual?.summary"
           @cost-line-changed="$emit('reload-job')"
+          @quote-created="$emit('quote-created')"
+          @quote-accepted="$emit('quote-accepted')"
+          @invoice-created="$emit('invoice-created')"
+          @quote-deleted="$emit('quote-deleted')"
+          @invoice-deleted="$emit('invoice-deleted')"
         />
       </div>
       <div v-if="activeTab === 'financial'" class="h-full p-4 md:p-6">
@@ -170,6 +176,8 @@ const emit = defineEmits<{
   (e: 'quote-created'): void
   (e: 'quote-accepted'): void
   (e: 'invoice-created'): void
+  (e: 'quote-deleted'): void
+  (e: 'invoice-deleted'): void
   (e: 'delete-job'): void
   (e: 'reload-job'): void
   (e: 'job-updated', job: unknown): void

--- a/src/components/shared/CompactSummaryCard.vue
+++ b/src/components/shared/CompactSummaryCard.vue
@@ -139,6 +139,6 @@ function formatCurrency(value: number): string {
 <style scoped>
 .compact-summary-card {
   min-width: 200px;
-  max-width: 250px;
+  max-width: 325px;
 }
 </style>

--- a/src/composables/useFinances.ts
+++ b/src/composables/useFinances.ts
@@ -1,0 +1,281 @@
+import { computed, ref, watch } from 'vue'
+import { toast } from 'vue-sonner'
+import { z } from 'zod'
+import { api } from '../api/client'
+import { schemas } from '../api/generated/api'
+import { AxiosError } from 'axios'
+import { debugLog } from '../utils/debug'
+
+type Job = z.infer<typeof schemas.Job>
+type Invoice = z.infer<typeof schemas.Invoice>
+
+interface UseFinancesProps {
+  jobData: Job | null
+  jobId?: string
+}
+
+interface UseFinancesEmits {
+  'quote-created': () => void
+  'quote-accepted': () => void
+  'invoice-created': () => void
+  'quote-deleted': () => void
+  'invoice-deleted': () => void
+}
+
+export function useFinances(props: UseFinancesProps, emit?: UseFinancesEmits) {
+  // --- STATE MANAGEMENT ---
+  // Local state for quotes
+  const isQuoteDeleted = ref(false)
+  const isDeletingQuote = ref(false)
+  const isCreatingQuote = ref(false)
+  const isAcceptingQuote = ref(false)
+
+  // Local state for invoices
+  const isCreatingInvoice = ref(false)
+  const deletingInvoiceId = ref<string | null>(null) // Track which invoice is being deleted
+
+  // --- COMPUTED PROPERTIES ---
+  const invoices = ref<Array<Invoice>>([])
+
+  const estimateTotal = computed(() => props.jobData?.latest_estimate?.summary?.rev || 0)
+  const timeAndExpenses = computed(() => {
+    const costLines = props.jobData?.latest_actual?.cost_lines
+    return costLines?.reduce((sum, line) => sum + (line.total_rev || 0), 0) || 0
+  })
+
+  const invoiceTotal = computed(() => {
+    if (!invoices.value.length) return 0
+    return invoices.value.reduce((sum, invoice) => sum + (invoice.total_excl_tax || 0), 0)
+  })
+
+  const toBeInvoiced = computed(() => {
+    const actualTotal = props.jobData?.latest_actual?.summary?.rev || 0
+    return Math.max(0, actualTotal - invoiceTotal.value)
+  })
+
+  const quoteTotal = computed(() => {
+    if (isQuoteDeleted.value) return 0
+    return props.jobData?.quote?.total_excl_tax || 0
+  })
+
+  const daysUntilDeadline = computed(() => {
+    if (!props.jobData?.delivery_date) return 0
+    const deliveryDate = new Date(props.jobData.delivery_date)
+    const today = new Date()
+    const diffTime = deliveryDate.getTime() - today.getTime()
+    return Math.ceil(diffTime / (1000 * 60 * 60 * 24))
+  })
+
+  const quoteUrl = computed(() => {
+    if (isQuoteDeleted.value) return null
+    return props.jobData?.quote?.online_url || null
+  })
+
+  // --- FORMATTING FUNCTIONS ---
+  const formatCurrency = (amount: number | undefined | null): string => {
+    if (amount === null || amount === undefined) {
+      return new Intl.NumberFormat('en-NZ', { style: 'currency', currency: 'NZD' }).format(0)
+    }
+    return new Intl.NumberFormat('en-NZ', { style: 'currency', currency: 'NZD' }).format(amount)
+  }
+
+  const formatDate = (dateString: string | null | undefined) => {
+    if (!dateString) return 'N/A'
+    return new Date(dateString).toLocaleDateString('en-NZ', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    })
+  }
+
+  // --- QUOTE METHODS ---
+  const createQuote = async () => {
+    if (!props.jobData?.id || isCreatingQuote.value) return
+    isCreatingQuote.value = true
+    try {
+      const response = await api.api_xero_create_quote_create(undefined, {
+        params: { job_id: props.jobData.id },
+      })
+      if (!response.success) {
+        debugLog(response.error || 'Failed to create quote')
+        return
+      }
+      toast.success('Quote created successfully!')
+      isQuoteDeleted.value = false
+      emit?.['quote-created']?.()
+    } catch (err) {
+      debugLog('Error creating quote:', err)
+      toast.error('Failed to create quote.')
+    } finally {
+      isCreatingQuote.value = false
+    }
+  }
+
+  const acceptQuote = async () => {
+    if (!props.jobData?.id || isAcceptingQuote.value) return
+    isAcceptingQuote.value = true
+    try {
+      const response = await api.job_rest_jobs_quote_accept_create(undefined, {
+        params: { job_id: props.jobData.id },
+      })
+      if (response.success) {
+        toast.success('Quote accepted successfully!')
+        emit?.['quote-accepted']?.()
+      } else {
+        toast.error('Failed to accept quote')
+      }
+    } catch (err) {
+      debugLog('Error accepting quote:', err)
+      toast.error('Failed to accept quote.')
+    } finally {
+      isAcceptingQuote.value = false
+    }
+  }
+
+  const goToQuoteOnXero = () => {
+    if (quoteUrl.value && quoteUrl.value !== '#') {
+      window.open(quoteUrl.value, '_blank')
+    }
+  }
+
+  const deleteQuoteOnXero = async () => {
+    if (!props.jobData?.id || isDeletingQuote.value) return
+    isDeletingQuote.value = true
+    try {
+      const response = await api.api_xero_delete_quote_destroy(undefined, {
+        params: { job_id: props.jobData.id },
+      })
+      if (!response.success) {
+        debugLog(response.error || 'Failed to delete quote')
+        return
+      }
+      isQuoteDeleted.value = true
+      toast.success('Quote deleted successfully!')
+      emit?.['quote-deleted']?.()
+    } catch (err) {
+      debugLog('Error deleting quote:', err)
+      toast.error('Failed to delete quote.')
+    } finally {
+      isDeletingQuote.value = false
+    }
+  }
+
+  // --- INVOICE METHODS ---
+  const createInvoice = async () => {
+    if (!props.jobData?.id || isCreatingInvoice.value) return
+    isCreatingInvoice.value = true
+    try {
+      const response = await api.api_xero_create_invoice_create(undefined, {
+        params: { job_id: props.jobData.id },
+      })
+      if (!response.success) {
+        debugLog(response.error || 'Failed to create invoice')
+        return
+      }
+      toast.success('Invoice created successfully!')
+      emit?.['invoice-created']?.()
+    } catch (err: unknown) {
+      let msg = 'Unexpected error while trying to create invoice.'
+      debugLog('Error creating invoice:', err)
+      if ((err as AxiosError).isAxiosError) {
+        const axiosErr = err as AxiosError<{ message: string }>
+        msg = axiosErr.response?.data?.message ?? msg
+      }
+      toast.error(`Failed to create invoice: ${msg}`)
+    } finally {
+      isCreatingInvoice.value = false
+    }
+  }
+
+  const goToInvoiceOnXero = (url: string | null | undefined) => {
+    if (url && url !== '#') {
+      window.open(url, '_blank')
+    } else {
+      toast.error('No online URL available for this invoice.')
+    }
+  }
+
+  const deleteInvoiceOnXero = async (invoiceXeroId: string) => {
+    if (!props.jobData?.id || deletingInvoiceId.value) return
+    deletingInvoiceId.value = invoiceXeroId
+    try {
+      const response = await api.api_xero_delete_invoice_destroy(undefined, {
+        params: { job_id: props.jobData.id },
+        queries: { xero_invoice_id: invoiceXeroId },
+      })
+      toast.success('Invoice deleted successfully!')
+      emit?.['invoice-deleted']?.()
+      invoices.value = invoices.value.filter((invoice) => invoice.xero_id !== response.xero_id)
+    } catch (err) {
+      debugLog('Error deleting invoice:', err)
+      toast.error('Failed to delete invoice.')
+    } finally {
+      deletingInvoiceId.value = null
+    }
+  }
+
+  // --- WATCHERS ---
+  watch(
+    () => props.jobData?.id,
+    (newJobId) => {
+      if (newJobId) {
+        isQuoteDeleted.value = false
+        deletingInvoiceId.value = null
+      }
+    },
+  )
+
+  watch(
+    () => props.jobData?.invoices,
+    (newInvoices) => {
+      // Create a copy of the array to ensure we don't mutate the prop
+      invoices.value = newInvoices ? [...newInvoices] : []
+    },
+    { immediate: true, deep: true }, // immediate: true runs the watcher on component mount
+  )
+
+  watch(
+    () => props.jobData?.quoted,
+    (isQuoted) => {
+      if (isQuoted && isQuoteDeleted.value) {
+        isQuoteDeleted.value = false
+      }
+    },
+  )
+
+  return {
+    // Financial metrics
+    estimateTotal,
+    timeAndExpenses,
+    invoiceTotal,
+    toBeInvoiced,
+    quoteTotal,
+    daysUntilDeadline,
+    quoteUrl,
+
+    // Invoice management
+    invoices,
+    isCreatingInvoice,
+    deletingInvoiceId,
+
+    // Quote operations
+    isQuoteDeleted,
+    isDeletingQuote,
+    isCreatingQuote,
+    isAcceptingQuote,
+
+    // Actions
+    createQuote,
+    acceptQuote,
+    deleteQuoteOnXero,
+    goToQuoteOnXero,
+
+    createInvoice,
+    goToInvoiceOnXero,
+    deleteInvoiceOnXero,
+
+    // Formatting
+    formatCurrency,
+    formatDate,
+  }
+}


### PR DESCRIPTION
## 📝 Description

This PR refactors two main tabs of `JobView`: `JobActualTab` and `JobFinancialTab`, to make it easier to check core financial information from the cost lines before invoicing (Cindy request).

## 🚀 Changes

- Extracted common "financial" (Xero operations and general logic from the previous component) logic to a new composable,`useFinances`.
- Redesigned the `JobActualTab` to include the new elements, such as the little KPI cards and the invoice management grid.
- Added two new buttons "Print" and "Download" to `JobQuoteTab`.
- Added the quote management grid to `JobQuoteTab`

## ✅ Checklist

**Vue.js (Composition API)**

- [X] Used Composition API (`<script setup>` & composables), no heavy logic in templates
- [X] UI logic extracted to reusable composables
- [ ] Components are focused & small (<200 LOC)
- [X] Communication via `props` and `emit`, no direct parent/child ref duplication
- [X] State management in Pinia; no ad-hoc reactive globals

**Quality & Formatting**

- [X] Passes Prettier (`npx prettier --check .`)
- [X] Passes ESLint with zero warnings (`npx eslint . --ext .js,.ts,.vue`)
- [ ] Added JSDoc comments for all props and emitted events
- [ ] New or updated unit/E2E tests included
