### PR TITLE
fix(deploy): remove file logging from frontend deployment script

### DIFF
--- a/scripts/deploy_frontend.sh
+++ b/scripts/deploy_frontend.sh
@@ -7,33 +7,12 @@ set -e  # Exit on any error
 
 # Configuration
 PROJECT_PATH="/opt/workflow_app/jobs_manager_front"
-LOG_FILE="$PROJECT_PATH/logs/deploy_machine.log"
-
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-BLUE='\033[0;34m'
-NC='\033[0m' # No Color
-
-# Logging function
-log() {
-    echo -e "${BLUE}[$(date '+%Y-%m-%d %H:%M:%S')]${NC} $1" | tee -a "$LOG_FILE"
-}
-
-log_success() {
-    echo -e "${GREEN}[$(date '+%Y-%m-%d %H:%M:%S')] ✅ $1${NC}" | tee -a "$LOG_FILE"
-}
-
-log_error() {
-    echo -e "${RED}[$(date '+%Y-%m-%d %H:%M:%S')] ❌ $1${NC}" | tee -a "$LOG_FILE"
-}
 
 # Main deployment function
 main() {
-    log "Starting frontend deployment process..."
+    echo "Starting frontend deployment..."
 
     cd "$PROJECT_PATH"
-    mkdir -p logs
 
     # Update code from git
     git switch main
@@ -43,9 +22,9 @@ main() {
 
     # Update schema (graceful fallback if backend unavailable)
     if npm run update-schema 2>/dev/null; then
-        log_success "API schema updated"
+        echo "API schema updated"
     else
-        log "Backend unavailable - using existing schema"
+        echo "Using existing schema (backend unavailable)"
     fi
 
     # Install dependencies and build
@@ -56,10 +35,10 @@ main() {
     sudo systemctl restart vue
     sudo systemctl reload nginx
 
-    log_success "Frontend deployment completed successfully!"
+    echo "Frontend deployment completed"
 }
 
 # Handle script interruption
-trap 'log_error "Deployment interrupted"; exit 1' INT TERM
+trap 'echo "Deployment interrupted"; exit 1' INT TERM
 
 main


### PR DESCRIPTION
Frontend script should not create its own logs directory. Let systemd journal and backend logging handle output capture instead of creating separate log files.

🤖 Generated with [Claude Code](https://claude.ai/code)

## 📝 Description

_Short explanation of what you’ve built and why._

## 🔗 Related Issue

Closes #[issue-number]

## 🚀 Changes

- Bullet-list of feature additions or fixes (e.g. extracted `useChat` composable, split `ChatHistory` and `ChatInput` components, added Pinia store).
- …

## ✅ Checklist

**Vue.js (Composition API)**

- [ ] Used Composition API (`<script setup>` & composables), no heavy logic in templates
- [ ] UI logic extracted to reusable composables (`useChat`, etc.)
- [ ] Components are focused & small (<200 LOC)
- [ ] Communication via `props` and `emit`, no direct parent/child ref duplication
- [ ] State management in Pinia; no ad-hoc reactive globals
- [ ] Routes/components lazy-loaded where appropriate

**Quality & Formatting**

- [ ] Passes Prettier (`npx prettier --check .`)
- [ ] Passes ESLint with zero warnings (`npx eslint . --ext .js,.ts,.vue`)
- [ ] Added JSDoc comments for all props and emitted events
- [ ] New or updated unit/E2E tests included
