### PR TITLE
fix: ensure consistent formatting in generated API schema files

### DIFF
--- a/scripts/gen-api.js
+++ b/scripts/gen-api.js
@@ -8,6 +8,7 @@
 
 import SwaggerParser from '@apidevtools/swagger-parser'
 import { generateZodClientFromOpenAPI } from 'openapi-zod-client'
+import { execSync } from 'child_process'
 import fs from 'fs/promises'
 import path from 'path'
 
@@ -28,9 +29,10 @@ async function main() {
       apiClientName: 'api', // generates `export const api = new Zodios(...)`
       withAlias: true,
     },
+    prettierPath: '.prettierrc.json', // Use project's prettier config
   })
 
-  // 4. Append `export { endpoints };` if it’s missing
+  // 4. Append `export { endpoints };` if it's missing
   let content = await fs.readFile(outputPath, 'utf-8')
   if (!/export\s+\{\s*endpoints\s*\}/.test(content)) {
     content += '\nexport { endpoints };\n'
@@ -39,6 +41,10 @@ async function main() {
   } else {
     console.log('ℹ️  `export { endpoints };` already present')
   }
+
+  // 5. Format with project's prettier config for consistency
+  execSync(`npx prettier --write "${outputPath}"`, { stdio: 'inherit' })
+  console.log('✅ Applied Prettier formatting')
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary

Fixes inconsistent formatting in autogenerated API schema files by ensuring prettier always runs after code generation.

## Technical Changes

### Schema Generation Script (`scripts/gen-api.js`)
- Add automatic prettier formatting after TypeScript generation
- Import `execSync` for running prettier with project config
- Configure `openapi-zod-client` to use `.prettierrc.json`
- Fail fast if prettier fails (no silent errors/warnings)

### Schema Updates
- Update `schema.yml` to match backend's current 2-space indentation
- Ensures consistency with backend OpenAPI output format

## Problem Solved

Previously, generated TypeScript files had inconsistent formatting:
- Double quotes vs single quotes (violated project's `singleQuote: true`)
- Semicolons vs no semicolons (violated project's `semi: false`)
- Random formatting changes on each generation

Now schema generation is deterministic and follows project style guide.

## Test Plan

- [x] `npm run update-schema` runs successfully  
- [x] Generated TypeScript follows project's prettier config
- [x] No formatting diffs after generation
- [x] Script fails properly if prettier fails

🤖 Generated with [Claude Code](https://claude.ai/code)