### PR TITLE
fix: replace fetch with axios for file downloads to include auth cookies

### DIFF
--- a/src/components/job/JobAttachmentsTab.vue
+++ b/src/components/job/JobAttachmentsTab.vue
@@ -240,6 +240,7 @@ import { api } from '@/api/client'
 import { formatFileSize, formatDate } from '@/utils/string-formatting'
 import type { z } from 'zod'
 import { debugLog } from '@/utils/debug'
+import axios from 'axios'
 
 type JobFile = z.infer<typeof schemas.JobFile> & {
   thumbnailError?: boolean
@@ -500,15 +501,13 @@ async function downloadFile(file: JobFile) {
   }
 
   try {
-    // Fetch the file as a blob to force download
+    // Use axios to ensure cookies are sent with the request for authentication
+    const response = await axios.get(file.download_url, {
+      responseType: 'blob',
+      withCredentials: true, // Explicitly set to ensure cookies are sent
+    })
 
-    // NOTE: the use of fetch here is to ensure we can handle large files and avoid CORS issues, justified for the simple download.
-    const response = await fetch(file.download_url)
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`)
-    }
-
-    const blob = await response.blob()
+    const blob = response.data
     const url = window.URL.createObjectURL(blob)
 
     // Open file in new tab for viewing/printing


### PR DESCRIPTION
File downloads were failing because fetch doesn't send authentication cookies by default. Switched to axios with withCredentials: true to ensure proper authentication.

🤖 Generated with [Claude Code](https://claude.ai/code)

## 📝 Description

_Short explanation of what you’ve built and why._

## 🔗 Related Issue

Closes #[issue-number]

## 🚀 Changes

- Bullet-list of feature additions or fixes (e.g. extracted `useChat` composable, split `ChatHistory` and `ChatInput` components, added Pinia store).
- …

## ✅ Checklist

**Vue.js (Composition API)**

- [ ] Used Composition API (`<script setup>` & composables), no heavy logic in templates
- [ ] UI logic extracted to reusable composables (`useChat`, etc.)
- [ ] Components are focused & small (<200 LOC)
- [ ] Communication via `props` and `emit`, no direct parent/child ref duplication
- [ ] State management in Pinia; no ad-hoc reactive globals
- [ ] Routes/components lazy-loaded where appropriate

**Quality & Formatting**

- [ ] Passes Prettier (`npx prettier --check .`)
- [ ] Passes ESLint with zero warnings (`npx eslint . --ext .js,.ts,.vue`)
- [ ] Added JSDoc comments for all props and emitted events
- [ ] New or updated unit/E2E tests included
