### PR TITLE
Fix: preserve newlines in job description editing

### DIFF
--- a/src/composables/useJobAutosave.ts
+++ b/src/composables/useJobAutosave.ts
@@ -87,6 +87,12 @@ export function createJobAutosave(opts: JobAutosaveOptions): JobAutosaveApi {
     ((key: string, value: unknown) => {
       if (value == null) return value
       if (typeof value === 'string') {
+        // For description and notes fields, preserve newlines
+        // Only trim leading/trailing whitespace
+        if (key === 'description' || key === 'notes') {
+          return value.trim()
+        }
+
         // trim and collapse internal whitespace
         const collapsed = value.trim().replace(/\s+/g, ' ')
 


### PR DESCRIPTION
## Summary
- Fixed issue where adding newlines to job descriptions wasn't triggering autosave
- Autosave normalization was collapsing all whitespace (including newlines) to single spaces
- Now preserves formatting for `description` and `notes` fields while maintaining normalization for other fields

## Test plan
- [x] Edit a job description and add newlines in the middle
- [x] Verify changes are detected and saved
- [x] Confirm other fields still normalize whitespace properly

🤖 Generated with [Claude Code](https://claude.ai/code)