### PR TITLE
Refactor/kanban search

### DIFF
--- a/src/plugins/axios.ts
+++ b/src/plugins/axios.ts
@@ -17,7 +17,7 @@ export const getApiBaseUrl = () => {
 }
 
 axios.defaults.baseURL = getApiBaseUrl()
-axios.defaults.timeout = 20000
+axios.defaults.timeout = 60000
 axios.defaults.withCredentials = true
 
 axios.interceptors.request.use(

--- a/src/services/kanban-categorization.service.ts
+++ b/src/services/kanban-categorization.service.ts
@@ -74,6 +74,20 @@ export class KanbanCategorizationService {
       colorTheme: 'emerald',
       badgeColorClass: 'bg-emerald-500',
     },
+    special: {
+      columnId: 'special',
+      columnTitle: 'Special',
+      statusKey: 'special',
+      colorTheme: 'gray',
+      badgeColorClass: 'bg-gray-500',
+    },
+    archived: {
+      columnId: 'archived',
+      columnTitle: 'Archived',
+      statusKey: 'archived',
+      colorTheme: 'slate',
+      badgeColorClass: 'bg-slate-500',
+    },
   }
 
   // Status to column mapping for quick lookup - based on Corrin's mapping table
@@ -97,7 +111,7 @@ export class KanbanCategorizationService {
     // Additional common backend statuses
     active: 'in_progress',
     pending: 'awaiting_approval',
-    special: 'draft', // Show special jobs in draft
+    special: 'special',
     archived: 'archived',
   }
 

--- a/src/views/KanbanView.vue
+++ b/src/views/KanbanView.vue
@@ -112,7 +112,7 @@
               </div>
 
               <div class="hidden lg:block">
-                <div class="w-full mx-auto px-2">
+                <div class="w-full mx-auto px-2 overflow-x-auto">
                   <div
                     class="grid gap-2 xl:gap-3"
                     :style="`grid-template-columns: repeat(${visibleStatusChoices.length}, minmax(0, 1fr))`"


### PR DESCRIPTION
## Summary

This PR fixes the following tickets:

- [Searching doesn't show which stage the jobs are at](https://trello.com/c/c1amTAGI/80-searching-of-jobs-now-not-showing-which-stage-they-are-at)
- [Cannot search and then change status of job - all columns disappear](https://trello.com/c/zRSpVkrt/81-cannot-search-and-then-change-status-of-job-columns-all-disappear)
- [Names of staff disappear when searching for jobs - cannot drag](https://trello.com/c/gLCry44U/83-names-of-staff-disappear-when-searching-for-jobs-so-they-can-drag-name-of-staff-member-who-is-working-on-the-job)