### PR TITLE
fix: accept quote button updates job status to approved

### DIFF
--- a/src/components/job/JobQuoteTab.vue
+++ b/src/components/job/JobQuoteTab.vue
@@ -114,7 +114,7 @@
                         v-if="!isQuoteAccepted"
                         size="sm"
                         class="bg-emerald-600 hover:bg-emerald-700 text-white"
-                        :disabled="isAcceptingQuote"
+                        :disabled="isAcceptingQuote || !canAcceptQuote"
                         @click="acceptQuote"
                       >
                         <svg
@@ -569,6 +569,7 @@ type Quote = z.infer<typeof schemas.Quote>
 const props = defineProps<{
   jobId: string
   jobNumber: string
+  jobStatus: string
   pricingMethodology: string
   quoted: boolean
   fullyInvoiced: boolean
@@ -656,6 +657,10 @@ const hasCostSetQuote = computed(
 )
 const hasXeroQuote = computed(() => !!xeroQuote.value)
 const isQuoteAccepted = computed(() => !!props.quoteAcceptanceDate)
+const canAcceptQuote = computed(() => {
+  // Button should only be enabled if status is draft or awaiting_approval
+  return props.jobStatus === 'draft' || props.jobStatus === 'awaiting_approval'
+})
 const localQuote = computed(() => xeroQuote.value) // Xero
 
 // Check if estimate data is available for copying

--- a/src/components/job/JobViewTabs.vue
+++ b/src/components/job/JobViewTabs.vue
@@ -52,11 +52,13 @@
         <JobQuoteTab
           :job-id="jobId"
           :job-number="jobNumberString"
+          :job-status="jobStatusString"
           :pricing-methodology="pricingMethodologyString"
           :quoted="quotedBoolean"
           :fully-invoiced="fullyInvoicedBoolean"
           @quote-imported="$emit('quote-imported', $event)"
           @cost-line-changed="$emit('reload-job')"
+          @quote-accepted="$emit('quote-accepted')"
         />
       </div>
       <div v-if="activeTab === 'actual'" class="h-full p-4 md:p-6">
@@ -179,6 +181,7 @@ const props = defineProps<{
   activeTab: JobTabKey
   jobId: string
   jobNumber: number
+  jobStatus?: string
   chargeOutRate?: number
   pricingMethodology?: string
   quoted?: boolean
@@ -189,6 +192,7 @@ const props = defineProps<{
 
 // Computed props with proper types for components
 const jobNumberString = computed(() => props.jobNumber.toString())
+const jobStatusString = computed(() => props.jobStatus || '')
 const pricingMethodologyString = computed(() => props.pricingMethodology || '')
 const quotedBoolean = computed(() => props.quoted || false)
 const fullyInvoicedBoolean = computed(() => props.fullyInvoiced || false)

--- a/src/views/JobView.vue
+++ b/src/views/JobView.vue
@@ -242,12 +242,14 @@
           @change-tab="setTab"
           :job-id="jobId"
           :job-number="jobHeader.job_number"
+          :job-status="localJobStatus"
           :charge-out-rate="companyDefaults?.charge_out_rate ?? 0"
           :pricing-methodology="jobHeader.pricing_methodology || ''"
           :quoted="jobHeader.quoted"
           :fully-invoiced="jobHeader.fully_invoiced"
           :paid="jobHeader?.paid ?? false"
           :company-defaults="companyDefaults"
+          @quote-accepted="handleQuoteAccepted"
         />
       </template>
 
@@ -373,6 +375,11 @@ const handlePaidUpdate = (newVal: boolean) => {
 const handlePricingMethodologyUpdate = (newMethod: string) => {
   localPricingMethodology.value = newMethod
   headerAutosave?.handlePricingMethodologyUpdate(newMethod)
+}
+
+const handleQuoteAccepted = () => {
+  // When quote is accepted, update job status to approved using existing mechanism
+  handleStatusUpdate('approved')
 }
 
 const companyDefaultsStore = useCompanyDefaultsStore()


### PR DESCRIPTION
## Summary
- Accept Quote button now automatically changes job status to 'Approved' when clicked
- Button is disabled unless job status is 'draft' or 'awaiting_approval'
- Provides an alternative workflow for approving jobs directly from the Quote tab

## Changes
- Pass job status through component hierarchy (JobView → JobViewTabs → JobQuoteTab)
- Add validation to disable Accept Quote button for inappropriate job states
- Hook up quote-accepted event to trigger existing status update mechanism
- Reuse existing `handleStatusUpdate` to avoid code duplication

## Test Plan
- [ ] Test that Accept Quote button is enabled only when job status is 'draft' or 'awaiting_approval'
- [ ] Test that clicking Accept Quote changes job status to 'approved'
- [ ] Test that Accept Quote button is disabled for other job statuses
- [ ] Verify job status updates correctly in the UI after accepting quote

🤖 Generated with [Claude Code](https://claude.ai/code)