### PR TITLE
feat: add quote chip to banner and fix schema formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "format": "prettier --write src/",
     "prepare": "simple-git-hooks",
     "gen:api": "node ./scripts/gen-api.js",
-    "update-schema": "(curl -f -o schema.yml http://localhost:8000/api/schema/ 2>/dev/null || echo 'Backend not available, using existing schema.yml') && npm run gen:api"
+    "update-schema": "(curl -f -o schema.yml http://localhost:8000/api/schema/ 2>/dev/null || echo 'Backend not available, using existing schema.yml') && npx prettier --write schema.yml && npm run gen:api"
   },
   "dependencies": {
     "@internationalized/date": "^3.8.2",


### PR DESCRIPTION
## Summary
- Add Quote chip to the KPI banner for fixed price jobs
- Update 'To Be Invoiced' calculation to use quoted amount for fixed price jobs
- Fix schema.yml formatting issue to prevent false changes during commits

## Changes

### Quote Banner Enhancements
- Added Quote chip between Estimate and Time & Expenses (only shown for fixed price jobs)
- Display quoted amount fetched from costs summary API
- Updated 'To Be Invoiced' calculation:
  - Fixed price jobs: Uses quoted amount
  - T&M jobs: Uses actual time & expenses

### Schema Formatting Fix
- Added prettier formatting to update-schema script
- Ensures consistent formatting after schema download from backend
- Prevents whitespace-only changes during commits

## Test Plan
- [ ] Verify Quote chip appears for fixed price jobs between Estimate and Time & Expenses
- [ ] Verify Quote chip does NOT appear for T&M jobs
- [ ] Verify 'To Be Invoiced' uses quoted amount for fixed price jobs
- [ ] Verify 'To Be Invoiced' uses actual T&M for time & materials jobs
- [ ] Run `npm run update-schema` and verify no whitespace changes in schema.yml

Fixes: https://trello.com/c/KROKWVum/124-quote-bug-feature-3-the-little-banner-needs-tweaking-for-quotes

🤖 Generated with [Claude Code](https://claude.ai/code)