### PR TITLE
fix: sort actual cost lines by type and newest first

### DIFF
--- a/src/components/job/JobActualTab.vue
+++ b/src/components/job/JobActualTab.vue
@@ -529,7 +529,31 @@ async function loadActualCosts() {
   try {
     const costSet: CostSet = await fetchCostSet(props.jobId, 'actual')
 
-    costLines.value = costSet.cost_lines
+    // Sort cost lines: Materials first, then Adjustments, then Time (labor)
+    // Within each type, newer items first (reverse the original order)
+    const sortedLines = [...costSet.cost_lines].sort((a, b) => {
+      // Define sort order for kinds
+      const kindOrder: Record<string, number> = {
+        material: 1,
+        adjust: 2,
+        time: 3,
+      }
+
+      const orderA = kindOrder[a.kind] || 999
+      const orderB = kindOrder[b.kind] || 999
+
+      // If different kinds, sort by kind order
+      if (orderA !== orderB) {
+        return orderA - orderB
+      }
+
+      // Same kind: reverse to show newer items first
+      // Assuming items are ordered by creation in the backend response,
+      // we want to reverse them within each type
+      return costSet.cost_lines.indexOf(b) - costSet.cost_lines.indexOf(a)
+    })
+
+    costLines.value = sortedLines
 
     revision.value = costSet.rev || 0
 


### PR DESCRIPTION
## Summary
Fixes the random ordering of cost lines in the Actual tab by implementing a consistent sort order.

## Changes
- Cost lines are now sorted by type:
  1. Materials (first)
  2. Adjustments (second)  
  3. Time/Labor (third)
- Within each type, newer items appear before older items
- Improves readability and provides a consistent view of actual costs

## Test Plan
- [ ] Verify Materials appear first in the actual tab
- [ ] Verify Adjustments appear after Materials
- [ ] Verify Time entries appear last
- [ ] Within each group, verify newer items appear before older items
- [ ] Test with jobs that have multiple cost lines of each type

Fixes: https://trello.com/c/exbvkD8s/98-actual-cost-lines-are-in-a-random-order

🤖 Generated with [Claude Code](https://claude.ai/code)