### PR TITLE
fix: correct pricing methodology check to match backend data model

### DIFF
--- a/src/components/job/JobActualTab.vue
+++ b/src/components/job/JobActualTab.vue
@@ -396,7 +396,7 @@ const toBeInvoiced = computed(() => {
 const invoiceButtonText = computed(() => {
   if (props.pricingMethodology === 'fixed_price') {
     return 'Create Invoice from Quote'
-  } else if (props.pricingMethodology === 'time_and_materials') {
+  } else if (props.pricingMethodology === 'time_materials') {
     return 'Create T&M Invoice'
   } else {
     console.error(`Unknown pricing methodology: ${props.pricingMethodology}`)


### PR DESCRIPTION
## Summary
Fixes console error "Unknown pricing methodology: time_materials" on job 96080 and other T&M jobs.

## Root Cause
Frontend was checking for `time_and_materials` but backend uses `time_materials` (without "and").

## Changes
- Updated `invoiceButtonText` computed property to check for `time_materials` instead of `time_and_materials`
- This matches the backend data model and API schema: `PricingMethodologyEnum = z.enum(['time_materials', 'fixed_price'])`

## Additional Investigation
While investigating the invoice adjustments issue from https://trello.com/c/jNLcplD7/116-jm-not-invoicing-properly-from-total-revenue-amount-when-adjusted:

**Frontend correctly includes adjustments in calculations:**
- `actualSummary.rev` includes all cost lines (materials, time, AND adjustments)  
- "Time & Expenses" display shows total including adjustments
- "To Be Invoiced" correctly uses total including adjustments

**The adjustments invoice issue is a backend problem:** The frontend passes only the job_id to the invoice creation endpoint. The backend needs to include adjustment cost lines when creating the invoice.

## Test Plan
- [ ] Verify no console errors on T&M jobs
- [ ] Verify invoice button shows "Create T&M Invoice" for T&M jobs
- [ ] Verify invoice button shows "Create Invoice from Quote" for fixed price jobs

🤖 Generated with [Claude Code](https://claude.ai/code)