### PR TITLE
refactor(openapi): improve staff API definitions and schema formatting

### DIFF
--- a/schema.yml
+++ b/schema.yml
@@ -109,14 +109,11 @@ paths:
   /accounts/api/staff/:
     get:
       operationId: accounts_api_staff_list
-      description: |-
-        API endpoint for listing and creating staff members.
-
-        Supports both GET (list all staff) and POST (create new staff) operations.
-        Requires authentication and staff permissions. Handles multipart/form data
-        for file uploads (e.g., profile pictures).
+      description: API endpoint for listing all staff members and creating new staff
+        members. Supports multipart/form data for file uploads (e.g., profile pictures).
+      summary: List and create staff members
       tags:
-        - accounts
+        - Staff Management
       security:
         - cookieAuth: []
       responses:
@@ -130,22 +127,19 @@ paths:
           description: ''
     post:
       operationId: accounts_api_staff_create
-      description: |-
-        API endpoint for listing and creating staff members.
-
-        Supports both GET (list all staff) and POST (create new staff) operations.
-        Requires authentication and staff permissions. Handles multipart/form data
-        for file uploads (e.g., profile pictures).
+      description: Create a new staff member with the provided details. Supports multipart/form
+        data for file uploads (e.g., profile pictures).
+      summary: Create a new staff member
       tags:
-        - accounts
+        - Staff Management
       requestBody:
         content:
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/Staff'
+              $ref: '#/components/schemas/StaffCreate'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/Staff'
+              $ref: '#/components/schemas/StaffCreate'
         required: true
       security:
         - cookieAuth: []
@@ -159,12 +153,11 @@ paths:
   /accounts/api/staff/{id}/:
     get:
       operationId: accounts_api_staff_retrieve
-      description: |-
-        API endpoint for retrieving, updating, and deleting individual staff members.
-
-        Supports GET (retrieve), PUT/PATCH (update), and DELETE operations on
-        specific staff members. Includes comprehensive logging for update operations
-        and handles multipart/form data for file uploads.
+      description: API endpoint for retrieving, updating, and deleting individual
+        staff members. Supports GET (retrieve), PUT/PATCH (update), and DELETE operations.
+        Includes comprehensive logging for update operations and handles multipart/form
+        data for file uploads.
+      summary: Retrieve, update, or delete staff member
       parameters:
         - in: path
           name: id
@@ -173,7 +166,7 @@ paths:
             format: uuid
           required: true
       tags:
-        - accounts
+        - Staff Management
       security:
         - cookieAuth: []
       responses:
@@ -185,12 +178,11 @@ paths:
           description: ''
     put:
       operationId: accounts_api_staff_update
-      description: |-
-        API endpoint for retrieving, updating, and deleting individual staff members.
-
-        Supports GET (retrieve), PUT/PATCH (update), and DELETE operations on
-        specific staff members. Includes comprehensive logging for update operations
-        and handles multipart/form data for file uploads.
+      description: API endpoint for retrieving, updating, and deleting individual
+        staff members. Supports GET (retrieve), PUT/PATCH (update), and DELETE operations.
+        Includes comprehensive logging for update operations and handles multipart/form
+        data for file uploads.
+      summary: Retrieve, update, or delete staff member
       parameters:
         - in: path
           name: id
@@ -199,7 +191,7 @@ paths:
             format: uuid
           required: true
       tags:
-        - accounts
+        - Staff Management
       requestBody:
         content:
           multipart/form-data:
@@ -220,12 +212,11 @@ paths:
           description: ''
     patch:
       operationId: accounts_api_staff_partial_update
-      description: |-
-        API endpoint for retrieving, updating, and deleting individual staff members.
-
-        Supports GET (retrieve), PUT/PATCH (update), and DELETE operations on
-        specific staff members. Includes comprehensive logging for update operations
-        and handles multipart/form data for file uploads.
+      description: API endpoint for retrieving, updating, and deleting individual
+        staff members. Supports GET (retrieve), PUT/PATCH (update), and DELETE operations.
+        Includes comprehensive logging for update operations and handles multipart/form
+        data for file uploads.
+      summary: Retrieve, update, or delete staff member
       parameters:
         - in: path
           name: id
@@ -234,7 +225,7 @@ paths:
             format: uuid
           required: true
       tags:
-        - accounts
+        - Staff Management
       requestBody:
         content:
           multipart/form-data:
@@ -254,12 +245,11 @@ paths:
           description: ''
     delete:
       operationId: accounts_api_staff_destroy
-      description: |-
-        API endpoint for retrieving, updating, and deleting individual staff members.
-
-        Supports GET (retrieve), PUT/PATCH (update), and DELETE operations on
-        specific staff members. Includes comprehensive logging for update operations
-        and handles multipart/form data for file uploads.
+      description: API endpoint for retrieving, updating, and deleting individual
+        staff members. Supports GET (retrieve), PUT/PATCH (update), and DELETE operations.
+        Includes comprehensive logging for update operations and handles multipart/form
+        data for file uploads.
+      summary: Retrieve, update, or delete staff member
       parameters:
         - in: path
           name: id
@@ -268,7 +258,7 @@ paths:
             format: uuid
           required: true
       tags:
-        - accounts
+        - Staff Management
       security:
         - cookieAuth: []
       responses:
@@ -9861,29 +9851,13 @@ components:
             $ref: '#/components/schemas/PurchaseOrderLineUpdate'
     PatchedStaff:
       type: object
+      description: Base serializer for Staff model with shared logic for create and
+        update operations.
       properties:
         id:
           type: string
           format: uuid
           readOnly: true
-        password:
-          type: string
-          maxLength: 128
-        last_login:
-          type: string
-          format: date-time
-          nullable: true
-        is_superuser:
-          type: boolean
-          title: Superuser status
-          description: Designates that this user has all permissions without explicitly
-            assigning them.
-        icon:
-          type: string
-          format: uri
-          nullable: true
-        password_needs_reset:
-          type: boolean
         email:
           type: string
           format: email
@@ -9898,6 +9872,10 @@ components:
           type: string
           nullable: true
           maxLength: 30
+        password:
+          type: string
+          writeOnly: true
+          maxLength: 128
         wage_rate:
           type: number
           format: double
@@ -9909,6 +9887,10 @@ components:
           type: string
           nullable: true
           maxLength: 100
+        icon:
+          type: string
+          format: uri
+          nullable: true
         raw_ims_data:
           nullable: true
         xero_user_id:
@@ -9922,16 +9904,22 @@ components:
           description: Date staff member left employment (null for current employees)
         is_staff:
           type: boolean
-        date_joined:
-          type: string
-          format: date-time
-        created_at:
-          type: string
-          format: date-time
-        updated_at:
-          type: string
-          format: date-time
-          readOnly: true
+        is_superuser:
+          type: boolean
+          title: Superuser status
+          description: Designates that this user has all permissions without explicitly
+            assigning them.
+        groups:
+          type: array
+          items:
+            type: integer
+          description: The groups this user belongs to. A user will get all permissions
+            granted to each of their groups.
+        user_permissions:
+          type: array
+          items:
+            type: integer
+          description: Specific permissions for this user.
         hours_mon:
           type: number
           format: double
@@ -9988,17 +9976,23 @@ components:
           exclusiveMaximum: true
           exclusiveMinimum: true
           description: Standard hours for Sunday, 0 for non-working day
-        groups:
-          type: array
-          items:
-            type: integer
-          description: The groups this user belongs to. A user will get all permissions
-            granted to each of their groups.
-        user_permissions:
-          type: array
-          items:
-            type: integer
-          description: Specific permissions for this user.
+        last_login:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+        date_joined:
+          type: string
+          format: date-time
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
     PreviewQuoteResponse:
       type: object
       description: Serializer for preview quote response.
@@ -10593,29 +10587,13 @@ components:
         * `assistant` - Assistant
     Staff:
       type: object
+      description: Base serializer for Staff model with shared logic for create and
+        update operations.
       properties:
         id:
           type: string
           format: uuid
           readOnly: true
-        password:
-          type: string
-          maxLength: 128
-        last_login:
-          type: string
-          format: date-time
-          nullable: true
-        is_superuser:
-          type: boolean
-          title: Superuser status
-          description: Designates that this user has all permissions without explicitly
-            assigning them.
-        icon:
-          type: string
-          format: uri
-          nullable: true
-        password_needs_reset:
-          type: boolean
         email:
           type: string
           format: email
@@ -10630,6 +10608,10 @@ components:
           type: string
           nullable: true
           maxLength: 30
+        password:
+          type: string
+          writeOnly: true
+          maxLength: 128
         wage_rate:
           type: number
           format: double
@@ -10641,6 +10623,10 @@ components:
           type: string
           nullable: true
           maxLength: 100
+        icon:
+          type: string
+          format: uri
+          nullable: true
         raw_ims_data:
           nullable: true
         xero_user_id:
@@ -10654,16 +10640,22 @@ components:
           description: Date staff member left employment (null for current employees)
         is_staff:
           type: boolean
-        date_joined:
-          type: string
-          format: date-time
-        created_at:
-          type: string
-          format: date-time
-        updated_at:
-          type: string
-          format: date-time
-          readOnly: true
+        is_superuser:
+          type: boolean
+          title: Superuser status
+          description: Designates that this user has all permissions without explicitly
+            assigning them.
+        groups:
+          type: array
+          items:
+            type: integer
+          description: The groups this user belongs to. A user will get all permissions
+            granted to each of their groups.
+        user_permissions:
+          type: array
+          items:
+            type: integer
+          description: Specific permissions for this user.
         hours_mon:
           type: number
           format: double
@@ -10720,6 +10712,133 @@ components:
           exclusiveMaximum: true
           exclusiveMinimum: true
           description: Standard hours for Sunday, 0 for non-working day
+        last_login:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+        date_joined:
+          type: string
+          format: date-time
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+        - created_at
+        - date_joined
+        - email
+        - first_name
+        - id
+        - last_login
+        - last_name
+        - updated_at
+    StaffCreate:
+      type: object
+      description: Base serializer for Staff model with shared logic for create and
+        update operations.
+      properties:
+        first_name:
+          type: string
+          maxLength: 30
+        last_name:
+          type: string
+          maxLength: 30
+        preferred_name:
+          type: string
+          nullable: true
+          maxLength: 30
+        email:
+          type: string
+          format: email
+          maxLength: 254
+        password:
+          type: string
+          writeOnly: true
+          maxLength: 128
+        wage_rate:
+          type: number
+          format: double
+          maximum: 100000000
+          minimum: -100000000
+          exclusiveMaximum: true
+          exclusiveMinimum: true
+        ims_payroll_id:
+          type: string
+          nullable: true
+          maxLength: 100
+        icon:
+          type: string
+          format: uri
+          nullable: true
+        hours_mon:
+          type: number
+          format: double
+          maximum: 100
+          minimum: -100
+          exclusiveMaximum: true
+          exclusiveMinimum: true
+          description: Standard hours for Monday, 0 for non-working day
+        hours_tue:
+          type: number
+          format: double
+          maximum: 100
+          minimum: -100
+          exclusiveMaximum: true
+          exclusiveMinimum: true
+          description: Standard hours for Tuesday, 0 for non-working day
+        hours_wed:
+          type: number
+          format: double
+          maximum: 100
+          minimum: -100
+          exclusiveMaximum: true
+          exclusiveMinimum: true
+          description: Standard hours for Wednesday, 0 for non-working day
+        hours_thu:
+          type: number
+          format: double
+          maximum: 100
+          minimum: -100
+          exclusiveMaximum: true
+          exclusiveMinimum: true
+          description: Standard hours for Thursday, 0 for non-working day
+        hours_fri:
+          type: number
+          format: double
+          maximum: 100
+          minimum: -100
+          exclusiveMaximum: true
+          exclusiveMinimum: true
+          description: Standard hours for Friday, 0 for non-working day
+        hours_sat:
+          type: number
+          format: double
+          maximum: 100
+          minimum: -100
+          exclusiveMaximum: true
+          exclusiveMinimum: true
+          description: Standard hours for Saturday, 0 for non-working day
+        hours_sun:
+          type: number
+          format: double
+          maximum: 100
+          minimum: -100
+          exclusiveMaximum: true
+          exclusiveMinimum: true
+          description: Standard hours for Sunday, 0 for non-working day
+        is_staff:
+          type: boolean
+        is_superuser:
+          type: boolean
+          title: Superuser status
+          description: Designates that this user has all permissions without explicitly
+            assigning them.
         groups:
           type: array
           items:
@@ -10734,9 +10853,8 @@ components:
       required:
         - email
         - first_name
-        - id
         - last_name
-        - updated_at
+        - password
     StaffDailyData:
       type: object
       description: Serializer for individual staff daily timesheet data

--- a/src/components/StaffFormModal.vue
+++ b/src/components/StaffFormModal.vue
@@ -74,7 +74,11 @@
                 type="password"
                 placeholder="Confirm Password"
                 :required="!props.staff"
+                :class="{ 'border-red-500 focus:ring-red-500': passwordMismatch }"
               />
+              <p v-if="passwordMismatch" class="text-sm text-red-600 mt-1">
+                Passwords do not match
+              </p>
             </div>
           </div>
           <div class="flex gap-2">
@@ -391,6 +395,13 @@ const initials = computed(() => {
   const first = form.value.first_name?.trim()[0] || ''
   const last = form.value.last_name?.trim()[0] || ''
   return (first + last).toUpperCase() || 'U'
+})
+
+const passwordMismatch = computed(() => {
+  if (!form.value.password && !form.value.password_confirmation) {
+    return false
+  }
+  return form.value.password !== form.value.password_confirmation
 })
 
 watch(

--- a/src/components/StaffFormModal.vue
+++ b/src/components/StaffFormModal.vue
@@ -55,6 +55,30 @@
           </div>
           <div class="flex gap-2">
             <div class="w-1/2">
+              <label class="block text-sm font-medium mb-1" for="password">Password</label>
+              <Input
+                id="password"
+                v-model="form.password"
+                type="password"
+                placeholder="Password"
+                :required="!props.staff"
+              />
+            </div>
+            <div class="w-1/2">
+              <label class="block text-sm font-medium mb-1" for="password_confirmation"
+                >Confirm Password</label
+              >
+              <Input
+                id="password_confirmation"
+                v-model="form.password_confirmation"
+                type="password"
+                placeholder="Confirm Password"
+                :required="!props.staff"
+              />
+            </div>
+          </div>
+          <div class="flex gap-2">
+            <div class="w-1/2">
               <label class="block text-sm font-medium mb-1" for="wage_rate"
                 >Wage Rate (NZD/hour)</label
               >
@@ -224,9 +248,6 @@
               ><input type="checkbox" v-model="form.is_staff" /> Staff</label
             >
             <label class="flex items-center gap-2"
-              ><input type="checkbox" v-model="form.is_active" /> Active</label
-            >
-            <label class="flex items-center gap-2"
               ><input type="checkbox" v-model="form.is_superuser" /> Superuser</label
             >
           </div>
@@ -281,7 +302,42 @@ import { toast } from 'vue-sonner'
 
 type Staff = z.infer<typeof schemas.Staff>
 
-const staffSchema = schemas.Staff
+const createStaffSchema = schemas.Staff.omit({
+  id: true,
+  last_login: true,
+  date_joined: true,
+  created_at: true,
+  updated_at: true,
+  groups: true,
+  user_permissions: true,
+  icon: true,
+})
+  .extend({
+    password: z.string().min(8, 'Password must be at least 8 characters'),
+    password_confirmation: z.string().min(1, 'Please confirm your password'),
+    groups: z.string(),
+    user_permissions: z.string(),
+    icon: z.instanceof(File).optional().nullable(),
+  })
+  .refine((data) => data.password === data.password_confirmation, {
+    message: "Passwords don't match",
+    path: ['password_confirmation'],
+  })
+
+const updateStaffSchema = schemas.PatchedStaff.extend({
+  password_confirmation: z.string().optional(),
+}).refine(
+  (data) => {
+    if (data.password || data.password_confirmation) {
+      return data.password === data.password_confirmation
+    }
+    return true
+  },
+  {
+    message: "Passwords don't match",
+    path: ['password_confirmation'],
+  },
+)
 
 const tabs = [
   { key: 'personal', label: 'Personal Info', icon: UserIcon },
@@ -300,6 +356,8 @@ const form = ref({
   last_name: '',
   preferred_name: '',
   email: '',
+  password: '',
+  password_confirmation: '',
   wage_rate: 0,
   ims_payroll_id: '',
   icon: null as File | null,
@@ -311,7 +369,6 @@ const form = ref({
   hours_sat: 0,
   hours_sun: 0,
   is_staff: false,
-  is_active: true,
   is_superuser: false,
   groups: '',
   user_permissions: '',
@@ -351,6 +408,8 @@ watch(
         last_name: staff.last_name,
         preferred_name: staff.preferred_name || '',
         email: staff.email,
+        password: '',
+        password_confirmation: '',
         wage_rate: staff.wage_rate || 0,
         ims_payroll_id: staff.ims_payroll_id || '',
         icon: null,
@@ -385,6 +444,8 @@ watch(
         last_name: '',
         preferred_name: '',
         email: '',
+        password: '',
+        password_confirmation: '',
         wage_rate: 0,
         ims_payroll_id: '',
         icon: null,
@@ -396,7 +457,6 @@ watch(
         hours_sat: 0,
         hours_sun: 0,
         is_staff: false,
-        is_active: true,
         is_superuser: false,
         groups: '',
         user_permissions: '',
@@ -429,9 +489,17 @@ async function submitForm() {
     typeof form.value.wage_rate,
   )
 
-  const parsed = staffSchema.safeParse({
-    ...form.value,
+  // Prepare data for validation - transform form data to match schema expectations
+  const validationData = {
+    first_name: form.value.first_name,
+    last_name: form.value.last_name,
+    preferred_name: form.value.preferred_name || null,
+    email: form.value.email,
+    ...(form.value.password && { password: form.value.password }),
     wage_rate: form.value.wage_rate,
+    ims_payroll_id: form.value.ims_payroll_id || null,
+    is_staff: form.value.is_staff,
+    is_superuser: form.value.is_superuser,
     hours_mon: form.value.hours_mon,
     hours_tue: form.value.hours_tue,
     hours_wed: form.value.hours_wed,
@@ -439,7 +507,33 @@ async function submitForm() {
     hours_fri: form.value.hours_fri,
     hours_sat: form.value.hours_sat,
     hours_sun: form.value.hours_sun,
-  })
+    // Convert groups and user_permissions from strings to arrays for validation
+    groups:
+      form.value.groups && form.value.groups.trim()
+        ? form.value.groups
+            .split(',')
+            .map((g) => Number(g.trim()))
+            .filter((g) => !isNaN(g))
+        : [],
+    user_permissions:
+      form.value.user_permissions && form.value.user_permissions.trim()
+        ? form.value.user_permissions
+            .split(',')
+            .map((p) => Number(p.trim()))
+            .filter((p) => !isNaN(p))
+        : [],
+    // Handle datetime fields - only include if valid
+    ...(form.value.last_login &&
+      form.value.last_login.trim() && { last_login: form.value.last_login }),
+    date_joined: form.value.date_joined,
+    // Add password_confirmation for validation only (not for API)
+    ...(form.value.password_confirmation && {
+      password_confirmation: form.value.password_confirmation,
+    }),
+  }
+
+  const schema = props.staff ? updateStaffSchema : createStaffSchema
+  const parsed = schema.safeParse(validationData)
 
   console.log('StaffFormModal - Schema validation result:', parsed)
 
@@ -452,14 +546,13 @@ async function submitForm() {
   try {
     // Prepare data for API - convert and format fields as expected by PatchedStaff schema
     const apiData = {
-      ...(props.staff && { id: props.staff.id }), // Include ID for update operations
       first_name: form.value.first_name,
       last_name: form.value.last_name,
       preferred_name: form.value.preferred_name || null,
       email: form.value.email,
+      ...(form.value.password && { password: form.value.password }), // Include password if provided
       wage_rate: form.value.wage_rate,
       ims_payroll_id: form.value.ims_payroll_id || null,
-      is_active: form.value.is_active,
       is_staff: form.value.is_staff,
       is_superuser: form.value.is_superuser,
       hours_mon: form.value.hours_mon,
@@ -489,22 +582,10 @@ async function submitForm() {
         form.value.last_login.trim() && { last_login: form.value.last_login }),
       date_joined: form.value.date_joined,
       // Don't send updated_at - it's auto-managed by backend
+      // Icon is handled separately via multipart/form-data if needed
     }
 
     console.log('StaffFormModal - API data being sent:', apiData)
-    console.log('StaffFormModal - Groups converted:', form.value.groups, '→', apiData.groups)
-    console.log(
-      'StaffFormModal - User permissions converted:',
-      form.value.user_permissions,
-      '→',
-      apiData.user_permissions,
-    )
-    console.log('StaffFormModal - ID included:', apiData.id)
-    console.log(
-      'StaffFormModal - Last login field included:',
-      'last_login' in apiData,
-      apiData.last_login,
-    )
 
     if (props.staff) {
       await updateStaff(props.staff.id, apiData)

--- a/src/composables/useStaffApi.ts
+++ b/src/composables/useStaffApi.ts
@@ -4,6 +4,7 @@ import { schemas } from '../api/generated/api'
 import { api } from '@/api/client'
 
 type Staff = z.infer<typeof schemas.Staff>
+type StaffCreate = z.infer<typeof schemas.StaffCreate>
 type KanbanStaff = z.infer<typeof schemas.KanbanStaff>
 
 export function useStaffApi() {
@@ -29,10 +30,10 @@ export function useStaffApi() {
     }
   }
 
-  async function createStaff(data: Record<string, unknown>): Promise<Staff> {
+  async function createStaff(data: StaffCreate): Promise<Staff> {
     error.value = null
     try {
-      return await api.accounts_api_staff_create(data as z.infer<typeof schemas.Staff>)
+      return await api.accounts_api_staff_create(data)
     } catch (e: unknown) {
       if (e instanceof Error) {
         error.value = e.message

--- a/src/views/AdminStaffView.vue
+++ b/src/views/AdminStaffView.vue
@@ -147,7 +147,7 @@ const selectedStaff = ref<Staff | null>(null)
 const filteredStaff = computed(() =>
   !search.value
     ? staffList.value
-    : staffList.value.filter((s) =>
+    : staffList.value.filter((s: Staff) =>
         [
           s.first_name,
           s.last_name,


### PR DESCRIPTION
The OpenAPI schema has been updated to enhance readability and API clarity. Indentation for parameters, tags, and security sections is now standardized, and long description strings are rewrapped. The 'accounts' tag has been renamed to 'Staff Management' for staff-related endpoints to provide more accurate categorization. A dedicated `StaffCreate` schema is introduced for staff creation, allowing for more precise validation. Additionally, concise `summary` descriptions have been added to staff API operations for better high-level overviews.

refactor(schema): improve staff schemas and standardize YAML indentation

Refactor the 'Staff' and 'PatchedStaff' OpenAPI schemas to enhance clarity and correctness. Reorder properties and explicitly mark fields like 'last_login', 'date_joined', 'created_at', and 'updated_at' as read-only. The 'password' field is now correctly marked as write-only. Introduce a new 'StaffCreate' schema to provide a dedicated and clearer definition for staff creation requests. Additionally, standardize the indentation of items within 'required' arrays across the entire schema for improved readability.

The changes improve the API contract by clearly defining read-only and write-only properties for staff data, which helps in generating more accurate client SDKs and documentation. The introduction of `StaffCreate` simplifies the API for creating new staff members. The consistent indentation throughout the schema enhances its overall readability and maintainability.

feat(api): add StaffCreate schema for staff creation endpoint
refactor(api): update Staff and PatchedStaff schemas to reflect API changes
refactor(api): simplify API endpoint descriptions for staff operations
feat(StaffFormModal): add password and confirm password fields for staff creation and update
fix(StaffFormModal): implement password validation and confirmation for staff forms
refactor(StaffFormModal): remove 'is_active' field as it's no longer present in the API
refactor(StaffFormModal): use distinct validation schemas for creating and updating staff
refactor(useStaffApi): update createStaff function to use StaffCreate schema
fix(AdminStaffView): add explicit type annotation for staff filtering

This commit introduces a new `StaffCreate` schema to accurately represent the data required for creating new staff members, which includes a mandatory password. The existing `Staff` and `PatchedStaff` schemas have been refined to align with the latest API structure, including reordering fields and making `password` optional for `Staff` but required for `StaffCreate`. API endpoint descriptions have been made more concise.

The `StaffFormModal` component has been updated to include password and confirm password input fields, with client-side validation to ensure passwords meet minimum length requirements and match. Separate Zod schemas (`createStaffSchema` and `updateStaffSchema`) are now used for validation based on whether a staff member is being created or updated, allowing for different validation rules (e.g., password required for creation, optional for update). The `is_active` field has been removed from the form as it's no longer part of the API.

The `useStaffApi` composable now correctly uses the `StaffCreate` type for the `createStaff` function, ensuring type safety and correct data submission. Finally, a minor fix in `AdminStaffView` adds an explicit type annotation for staff filtering to improve code clarity.