### PR TITLE
fix(build): improve schema update script resilience

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "format": "prettier --write src/",
     "prepare": "simple-git-hooks",
     "gen:api": "node ./scripts/gen-api.js",
-    "update-schema": "(curl -f -o schema.yml http://localhost:8000/api/schema/ 2>/dev/null || echo 'Backend not available, using existing schema.yml') && npx prettier --write schema.yml && npm run gen:api"
+    "update-schema": "node ./scripts/update-schema.js && npx prettier --write schema.yml && npm run gen:api"
   },
   "dependencies": {
     "@internationalized/date": "^3.8.2",

--- a/scripts/update-schema.js
+++ b/scripts/update-schema.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+import fs from 'fs'
+import { fileURLToPath } from 'url'
+import { dirname, join } from 'path'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+const projectRoot = join(__dirname, '..')
+
+async function fetchSchema() {
+  // Read the API URL from .env file
+  const envPath = join(projectRoot, '.env')
+  const envContent = fs.readFileSync(envPath, 'utf-8')
+  const match = envContent.match(/^VITE_API_BASE_URL=(.+)$/m)
+
+  const apiUrl = match[1].trim()
+  const schemaUrl = `${apiUrl}/api/schema/`
+
+  console.log(`Fetching schema from ${schemaUrl}...`)
+  const response = await fetch(schemaUrl, {
+    signal: AbortSignal.timeout(10000), // 10 second timeout
+  })
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}: ${response.statusText}`)
+  }
+
+  const schema = await response.text()
+  const schemaPath = join(projectRoot, 'schema.yml')
+  fs.writeFileSync(schemaPath, schema)
+  console.log(`✅ Schema fetched successfully`)
+}
+
+fetchSchema().catch((error) => {
+  console.log('⚠️  Could not fetch schema:', error.message)
+  // Don't fail the build - just continue with existing schema
+  process.exit(0)
+})


### PR DESCRIPTION
## Summary
- Replace hardcoded localhost URL with proper .env-based configuration
- Add graceful handling for backend unavailability during builds
- Improve deployment resilience across different environments

## Changes
- Created dedicated Node.js script (`scripts/update-schema.js`) for schema updates
- Script reads `VITE_API_BASE_URL` from `.env` file
- Added proper HTTP error handling
- Build continues with existing schema when backend is unavailable

## Test Plan
- [x] Tested with backend available - schema fetches successfully
- [x] Tested with backend unavailable - uses existing schema gracefully
- [x] Build completes successfully in both scenarios

🤖 Generated with [Claude Code](https://claude.ai/code)