### PR TITLE
Changed to a shared stock model so we don't double fetch

### DIFF
--- a/src/components/job/JobActualTab.vue
+++ b/src/components/job/JobActualTab.vue
@@ -496,10 +496,8 @@ const negativeStockIds = computed(() => [...negativeStockSet].sort())
 async function checkAndUpdateNegativeStocks() {
   negativeStockSet.clear()
 
-  // Ensure stock data is loaded
-  if (stockStore.items.length === 0) {
-    await stockStore.fetchStock()
-  }
+  // Simple call - store handles dedup
+  await stockStore.fetchStock()
 
   // Use stock store data instead of calling API directly
   for (const stock of stockStore.items) {

--- a/src/stores/stockStore.ts
+++ b/src/stores/stockStore.ts
@@ -17,14 +17,11 @@ export const useStockStore = defineStore('stock', () => {
   let inFlight: Promise<StockItem[]> | null = null
 
   async function fetchStock(force = false): Promise<StockItem[]> {
-    // Early return if already have data and not forcing
-    if (!force) {
-      if (items.value.length > 0) return items.value
-      if (loading.value && inFlight) return inFlight
-    }
+    // Return existing in-flight promise if one exists (unless forcing)
+    if (loading.value && inFlight && !force) return inFlight
 
-    // Return existing in-flight promise if one exists
-    if (loading.value && inFlight) return inFlight
+    // Early return if already have data and not forcing
+    if (!force && items.value.length > 0) return items.value
 
     loading.value = true
     inFlight = (async () => {

--- a/src/views/purchasing/ItemSelect.vue
+++ b/src/views/purchasing/ItemSelect.vue
@@ -33,9 +33,8 @@ const store = useStockStore()
 const searchTerm = ref('')
 
 onMounted(async () => {
-  if (store.items.length === 0 && !store.loading) {
-    await store.fetchStock()
-  }
+  // Simple call - store handles everything
+  await store.fetchStock()
 })
 
 const filteredItems = computed(() => {


### PR DESCRIPTION
## 📝 Description

_Short explanation of what you’ve built and why._

## 🔗 Related Issue

Closes #[issue-number]

## 🚀 Changes

- Bullet-list of feature additions or fixes (e.g. extracted `useChat` composable, split `ChatHistory` and `ChatInput` components, added Pinia store).
- …

## ✅ Checklist

**Vue.js (Composition API)**

- [ ] Used Composition API (`<script setup>` & composables), no heavy logic in templates
- [ ] UI logic extracted to reusable composables (`useChat`, etc.)
- [ ] Components are focused & small (<200 LOC)
- [ ] Communication via `props` and `emit`, no direct parent/child ref duplication
- [ ] State management in Pinia; no ad-hoc reactive globals
- [ ] Routes/components lazy-loaded where appropriate

**Quality & Formatting**

- [ ] Passes Prettier (`npx prettier --check .`)
- [ ] Passes ESLint with zero warnings (`npx eslint . --ext .js,.ts,.vue`)
- [ ] Added JSDoc comments for all props and emitted events
- [ ] New or updated unit/E2E tests included
