### PR TITLE
always show Archived column on kanban

### DIFF
--- a/src/composables/useOptimizedKanban.ts
+++ b/src/composables/useOptimizedKanban.ts
@@ -368,13 +368,10 @@ export function useOptimizedKanban(onJobsLoaded?: () => void) {
         .join(' ')}`,
     }))
 
-    // Add special and archived columns if they have jobs during search
+    // Add special column if it has jobs during search
     if (filteredJobs.value.length > 0) {
       const hasSpecialJobs = filteredJobs.value.some(
         (job) => KanbanCategorizationService.getColumnForStatus(job.status) === 'special',
-      )
-      const hasArchivedJobs = filteredJobs.value.some(
-        (job) => KanbanCategorizationService.getColumnForStatus(job.status) === 'archived',
       )
 
       if (hasSpecialJobs) {
@@ -384,21 +381,6 @@ export function useOptimizedKanban(onJobsLoaded?: () => void) {
             key: specialCol.columnId,
             label: specialCol.columnTitle,
             tooltip: `Status: ${specialCol.statusKey
-              .replace(/_/g, ' ')
-              .split(' ')
-              .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-              .join(' ')}`,
-          })
-        }
-      }
-
-      if (hasArchivedJobs) {
-        const archivedCol = KanbanCategorizationService.getColumnInfo('archived')
-        if (archivedCol) {
-          mainColumns.push({
-            key: archivedCol.columnId,
-            label: archivedCol.columnTitle,
-            tooltip: `Status: ${archivedCol.statusKey
               .replace(/_/g, ' ')
               .split(' ')
               .map((word) => word.charAt(0).toUpperCase() + word.slice(1))

--- a/src/services/kanban-categorization.service.ts
+++ b/src/services/kanban-categorization.service.ts
@@ -138,6 +138,7 @@ export class KanbanCategorizationService {
       this.COLUMN_STRUCTURE.in_progress,
       this.COLUMN_STRUCTURE.unusual,
       this.COLUMN_STRUCTURE.recently_completed,
+      this.COLUMN_STRUCTURE.archived,
     ]
   }
 
@@ -174,7 +175,7 @@ export class KanbanCategorizationService {
   }
 
   static isStatusHiddenFromKanban(status: string): boolean {
-    const hiddenStatuses = new Set(['special', 'rejected', 'archived'])
+    const hiddenStatuses = new Set(['special', 'rejected'])
     return hiddenStatuses.has(status)
   }
 


### PR DESCRIPTION
## 📝 Description

_Short explanation of what you’ve built and why._

## 🔗 Related Issue

Closes #[issue-number]

## 🚀 Changes

- Bullet-list of feature additions or fixes (e.g. extracted `useChat` composable, split `ChatHistory` and `ChatInput` components, added Pinia store).
- …

## ✅ Checklist

**Vue.js (Composition API)**

- [ ] Used Composition API (`<script setup>` & composables), no heavy logic in templates
- [ ] UI logic extracted to reusable composables (`useChat`, etc.)
- [ ] Components are focused & small (<200 LOC)
- [ ] Communication via `props` and `emit`, no direct parent/child ref duplication
- [ ] State management in Pinia; no ad-hoc reactive globals
- [ ] Routes/components lazy-loaded where appropriate

**Quality & Formatting**

- [ ] Passes Prettier (`npx prettier --check .`)
- [ ] Passes ESLint with zero warnings (`npx eslint . --ext .js,.ts,.vue`)
- [ ] Added JSDoc comments for all props and emitted events
- [ ] New or updated unit/E2E tests included
