### PR TITLE
Feat/add type inference to lines table

### DIFF
--- a/.kilocode/tasks/job-creation-quote-redirection-plan.md
+++ b/.kilocode/tasks/job-creation-quote-redirection-plan.md
@@ -1,0 +1,254 @@
+# Job Creation Quote Tab Redirection and Automatic Cost Line Copy - Architectural Plan
+
+## Executive Summary
+
+This plan outlines the modification of job creation behavior to automatically redirect users to the quote tab instead of the actual tab after job creation, automatically copy estimate cost lines to the quote cost set, and remove the manual "Copy from Estimate" button.
+
+## Current State Analysis
+
+### Job Creation Flow
+
+1. User fills out job creation form in `JobCreateView.vue`
+2. Form submission creates job via `jobService.createJob()`
+3. Cost lines are created in 'estimate' set (materials, workshop time, office time)
+4. User is redirected to `job-edit` route with `router.push({ name: 'job-edit', params: { id: job_id } })`
+
+### Tab Management
+
+- `JobView.vue` uses `useJobTabs('actual')` which defaults to 'actual' tab
+- Tabs are managed by `JobViewTabs.vue` component
+- Available tabs: estimate, quote, actual, costAnalysis, jobSettings, history, attachments, quotingChat
+
+### Cost Line Management
+
+- Cost lines are stored in CostSets by kind: 'estimate', 'quote', 'actual'
+- Manual copy functionality exists in `JobQuoteTab.vue` via `onCopyFromEstimate()` function
+- Copy process: fetches estimate CostSet, deletes existing quote lines, creates new quote lines from estimate data
+
+### Manual Copy Button
+
+- Located in `JobQuoteTab.vue` template (line 21-29)
+- Button is enabled when `hasEstimateData.value` is true
+- Triggers `onCopyFromEstimate()` which performs the copy operation
+
+## Proposed Changes
+
+### 1. Automatic Cost Line Copy During Job Creation
+
+**Location:** `src/views/JobCreateView.vue`
+
+**Current Code (lines 514-551):**
+
+```typescript
+const result = await jobService.createJob(formData.value)
+
+if (result.success && result.job_id) {
+  const job_id = result.job_id
+  try {
+    await costlineService.createCostLine(job_id, 'estimate', {
+      kind: 'material',
+      desc: 'Estimated materials',
+      quantity: 1,
+      unit_cost: formData.value.estimatedMaterials!,
+      unit_rev:
+        formData.value.estimatedMaterials! *
+        (1 + companyDefaultsStore.companyDefaults?.materials_markup),
+    })
+  } catch (error: unknown) {
+    toast.error((error as Error).message)
+    debugLog('Failed to create material cost line:', error)
+  }
+  // ... additional estimate cost lines ...
+}
+```
+
+**Proposed Code:**
+
+```typescript
+const result = await jobService.createJob(formData.value)
+
+if (result.success && result.job_id) {
+  const job_id = result.job_id
+
+  // Create estimate cost lines (existing logic)
+  const estimateLines = []
+  try {
+    const materialLine = await costlineService.createCostLine(job_id, 'estimate', {
+      kind: 'material',
+      desc: 'Estimated materials',
+      quantity: 1,
+      unit_cost: formData.value.estimatedMaterials!,
+      unit_rev:
+        formData.value.estimatedMaterials! *
+        (1 + companyDefaultsStore.companyDefaults?.materials_markup),
+    })
+    estimateLines.push(materialLine)
+  } catch (error: unknown) {
+    toast.error((error as Error).message)
+    debugLog('Failed to create material cost line:', error)
+  }
+
+  // ... create other estimate lines and collect them ...
+
+  // Automatically copy estimate lines to quote set
+  if (estimateLines.length > 0) {
+    try {
+      for (const estimateLine of estimateLines) {
+        await costlineService.createCostLine(job_id, 'quote', {
+          kind: estimateLine.kind,
+          desc: estimateLine.desc,
+          quantity: estimateLine.quantity,
+          unit_cost: estimateLine.unit_cost,
+          unit_rev: estimateLine.unit_rev,
+          ext_refs: estimateLine.ext_refs || {},
+          meta: estimateLine.meta || {},
+        })
+      }
+      debugLog('Successfully copied estimate lines to quote set')
+    } catch (error: unknown) {
+      toast.error('Job created but failed to copy cost lines to quote')
+      debugLog('Failed to copy estimate lines to quote:', error)
+    }
+  }
+}
+```
+
+### 2. Tab Redirection After Job Creation
+
+**Location:** `src/views/JobCreateView.vue`
+
+**Current Code (line 554):**
+
+```typescript
+router.push({ name: 'job-edit', params: { id: job_id } })
+```
+
+**Proposed Code:**
+
+```typescript
+router.push({
+  name: 'job-edit',
+  params: { id: job_id },
+  query: { tab: 'quote' },
+})
+```
+
+**Location:** `src/views/JobView.vue`
+
+**Current Code (line 357):**
+
+```typescript
+const { activeTab, setTab } = useJobTabs('actual')
+```
+
+**Proposed Code:**
+
+```typescript
+const route = useRoute()
+const defaultTab = (route.query.tab as JobTabKey) || 'actual'
+const { activeTab, setTab } = useJobTabs(defaultTab)
+```
+
+**Location:** `src/composables/useJobTabs.ts`
+
+**Current Code:**
+
+```typescript
+export function useJobTabs(initialTab: JobTabKey = 'estimate') {
+  const activeTab = ref<JobTabKey>(initialTab)
+  // ...
+}
+```
+
+**Proposed Code:**
+
+```typescript
+export function useJobTabs(initialTab: JobTabKey = 'actual') {
+  const activeTab = ref<JobTabKey>(initialTab)
+  // ...
+}
+```
+
+### 3. Remove Manual Copy Button
+
+**Location:** `src/components/job/JobQuoteTab.vue`
+
+**Current Code (lines 19-30):**
+
+```vue
+<div class="px-4 py-3 border-b border-slate-200 flex items-center justify-between">
+  <h3 class="text-lg font-semibold text-gray-900">Quote Details</h3>
+  <button
+    class="inline-flex items-center justify-center h-9 px-3 rounded-md bg-blue-600 text-white border border-blue-700 text-sm font-medium hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+    style="min-width: 0"
+    @click="onCopyFromEstimate"
+    :disabled="isLoading || !hasEstimateData"
+    :title="'Copy from Estimate'"
+  >
+    <Copy class="w-4 h-4 mr-1" /> Copy from Estimate
+  </button>
+</div>
+```
+
+**Proposed Code:**
+
+```vue
+<div class="px-4 py-3 border-b border-slate-200">
+  <h3 class="text-lg font-semibold text-gray-900">Quote Details</h3>
+</div>
+```
+
+## Implementation Steps
+
+### Phase 1: Core Functionality
+
+1. **Modify Job Creation Flow**
+
+   - Update `JobCreateView.vue` to collect created estimate lines
+   - Add automatic copy logic to quote set
+   - Handle errors gracefully (job creation succeeds even if copy fails)
+
+2. **Implement Tab Redirection**
+   - Modify router.push in `JobCreateView.vue` to include tab query parameter
+   - Update `JobView.vue` to read tab from query parameters
+   - Adjust `useJobTabs` default to 'actual' to maintain backward compatibility
+
+### Phase 2: Remove Manual Copy Button
+
+3. **Remove Manual Copy Button**
+   - Remove the copy button from `JobQuoteTab.vue` template
+   - Remove related logic and imports if no longer needed
+
+## Acceptance Criteria
+
+### Functional Requirements
+
+- [ ] After job creation, user is automatically redirected to the quote tab
+- [ ] Estimate cost lines are automatically copied to quote cost set during job creation
+- [ ] Manual copy button is completely removed
+- [ ] Job creation still succeeds even if automatic copy fails
+- [ ] Existing functionality for other tabs remains unchanged
+
+### Error Handling
+
+- [ ] Clear error messages if automatic copy fails
+- [ ] Job creation process continues even if copy operation fails
+- [ ] Debug logging for troubleshooting copy operations
+
+### User Experience
+
+- [ ] Seamless transition to quote tab after job creation
+- [ ] No duplicate cost lines created
+- [ ] Clear indication when quote data is pre-populated
+- [ ] Backward compatibility for existing job URLs without tab parameter
+
+### Technical Requirements
+
+- [ ] TypeScript types maintained throughout
+- [ ] API calls follow existing patterns
+- [ ] Error handling consistent with application standards
+- [ ] Performance impact minimized (copy happens during creation, not blocking UI)
+
+## Conclusion
+
+This architectural plan provides a clear path to implement the requested job creation behavior modifications. The changes are focused, backward-compatible, and follow existing application patterns. The automatic copy functionality eliminates the need for manual intervention while the tab redirection improves user workflow efficiency.

--- a/.kilocode/tasks/smart-costline-grid/type-column-inference-plan.md
+++ b/.kilocode/tasks/smart-costline-grid/type-column-inference-plan.md
@@ -1,0 +1,302 @@
+# SmartCostLinesTable Type Column Auto-Inference Implementation Plan
+
+## Overview
+
+Modify SmartCostLinesTable.vue to automatically infer the "Type" column (kind field) based on user actions, making it readonly while maintaining all existing functionality.
+
+## Requirements
+
+- **Item Selection**: When user selects an item → kind = 'material'
+- **Labour Selection**: When user selects special "Labour" item → kind = 'time'
+- **Description First**: When user types in description without selecting item → kind = 'adjust'
+- **Type Column**: Becomes readonly (badge only, no dropdown)
+- **Backward Compatibility**: Maintain existing validations and autosave logic
+
+## Current State Analysis
+
+### Type Column Behavior
+
+- Currently uses dropdown menu for manual kind selection ('material', 'time', 'adjust')
+- Editable based on `canEditKindForLine()` function
+- Changes trigger company defaults application and unit_rev recalculation
+
+### Item Selection
+
+- Uses ItemSelect component with stock items from store
+- Calls `onItemSelected(line)` when item changes
+
+### Description Editing
+
+- Editable via modal, currently doesn't affect kind
+
+## Implementation Plan
+
+### 1. Modify ItemSelect Component (`src/views/purchasing/ItemSelect.vue`)
+
+#### Add Mocked "Labour" Item
+
+```typescript
+// Add after filteredItems computed
+const mockedLabourItem = {
+  id: '__labour__',
+  description: 'Labour',
+  item_code: 'LABOUR',
+  unit_cost: companyDefaultsStore.companyDefaults?.wage_rate ?? 0,
+  unit_rev: companyDefaultsStore.companyDefaults?.charge_out_rate ?? 0,
+  quantity: null,
+}
+
+// Modify filteredItems to include mocked item
+const filteredItems = computed(() => {
+  const stockItems = store.items
+  const labourItem = [mockedLabourItem]
+
+  const allItems = [...stockItems, ...labourItem]
+
+  if (!searchTerm.value) return allItems
+  const term = searchTerm.value.toLowerCase()
+  return allItems.filter((item) => {
+    const searchableFields = [item.description, item.item_code].filter(Boolean)
+    return searchableFields.some((field) => field?.toLowerCase().includes(term))
+  })
+})
+```
+
+#### Update Display Logic
+
+```typescript
+const displayLabel = computed(() => {
+  if (!props.modelValue) return 'Select Item'
+  if (props.modelValue === '__labour__') return 'Labour'
+  const found = store.items.find((i: StockItem) => i.id == props.modelValue)
+  return found ? found.description || 'Stock Item' : 'Select Item'
+})
+```
+
+#### Add Kind Emit
+
+```typescript
+const emit = defineEmits<{
+  'update:modelValue': [string | null]
+  'update:description': [string]
+  'update:unit_cost': [number | null]
+  'update:kind': [KindOption | null] // New emit
+}>()
+
+// Update emit logic
+'onUpdate:modelValue': (val) => {
+  emit('update:modelValue', val as string | null)
+
+  if (val === '__labour__') {
+    emit('update:description', 'Labour')
+    emit('update:unit_cost', companyDefaultsStore.companyDefaults?.wage_rate ?? 0)
+    emit('update:kind', 'time')
+  } else {
+    const found = store.items.find((i: StockItem) => i.id == val)
+    if (found) {
+      emit('update:description', found.description || '')
+      emit('update:unit_cost', found.unit_cost || null)
+      emit('update:kind', 'material')
+    } else {
+      emit('update:description', '')
+      emit('update:unit_cost', null)
+      emit('update:kind', null)
+    }
+  }
+}
+```
+
+### 2. Update SmartCostLinesTable.vue Type Column
+
+#### Make Type Column Readonly
+
+Replace the entire Type column cell (lines 344-459) with:
+
+```typescript
+// Type / Kind - Now readonly badge only
+{
+  id: 'kind',
+  header: 'Type',
+  cell: ({ row }: RowCtx) => {
+    const line = displayLines.value[row.index]
+    const badge = getKindBadge(line)
+    return h(Badge, { class: `text-xs font-medium ${badge.class}` }, () => badge.label)
+  },
+  meta: { editable: false }, // Always readonly
+},
+```
+
+### 3. Update Item Column Logic
+
+#### Modify ItemSelect Usage
+
+In the Item column cell, update the ItemSelect component to handle kind inference:
+
+```typescript
+h(ItemSelect, {
+  modelValue: model,
+  disabled: !enabled,
+  onClick: (e: Event) => e.stopPropagation(),
+  'onUpdate:modelValue': async (val: string | null) => {
+    if (!enabled) return
+    selectedItemMap.set(line, val)
+
+    // Infer kind based on selection
+    let newKind: KindOption = 'adjust' // Default fallback
+    if (val === '__labour__') {
+      newKind = 'time'
+    } else if (val) {
+      newKind = 'material'
+    }
+
+    // Update kind if it changed
+    if (String(line.kind) !== newKind) {
+      updateLineKind(line, newKind)
+    }
+
+    onItemSelected(line)
+
+    // ... rest of existing logic for stock consumption and data updates
+  },
+  'onUpdate:description': (desc: string) => enabled && Object.assign(line, { desc }),
+  'onUpdate:unit_cost': (cost: number | null) => {
+    if (!enabled) return
+    Object.assign(line, { unit_cost: Number(cost ?? 0) })
+    if (kind !== 'time')
+      Object.assign(line, { unit_rev: apply(line).derived.unit_rev })
+    nextTick(() => {
+      if (!line.id && isLineReadyForSave(line)) maybeEmitCreate(line)
+    })
+  },
+}),
+```
+
+### 4. Add Description Change Handler
+
+#### Infer 'adjust' Kind on Description Edit
+
+Update the description modal save logic:
+
+```typescript
+// In the description modal
+'update:modelValue': (desc: string) => {
+  if (descModalLine) {
+    descModalLine.desc = desc
+
+    // Infer kind as 'adjust' if no item is selected and description is being set
+    const hasSelectedItem = selectedItemMap.get(descModalLine)
+    if (!hasSelectedItem && desc.trim() && String(descModalLine.kind) !== 'adjust') {
+      updateLineKind(descModalLine, 'adjust')
+    }
+  }
+}
+```
+
+### 5. Create Helper Function for Kind Updates
+
+#### Add updateLineKind Helper
+
+```typescript
+function updateLineKind(line: CostLine, newKind: KindOption) {
+  if (String(line.kind) === newKind) return
+
+  Object.assign(line, { kind: newKind })
+  onKindChanged(line)
+
+  // Apply company defaults for time
+  if (newKind === 'time') {
+    Object.assign(line, {
+      unit_cost: companyDefaultsStore.companyDefaults?.wage_rate ?? 0,
+      unit_rev: companyDefaultsStore.companyDefaults?.charge_out_rate ?? 0,
+    })
+  } else {
+    // Recalculate unit_rev with markup for material/adjust
+    const derived = apply(line).derived
+    Object.assign(line, { unit_rev: derived.unit_rev })
+  }
+
+  // Save if line has real ID and meets baseline
+  if (line.id && isLineReadyForSave(line)) {
+    console.log('Saving kind change:', line.id, newKind)
+    const patch: PatchedCostLineCreateUpdate = {
+      kind: newKind,
+      ...(newKind === 'time'
+        ? {
+            unit_cost: companyDefaultsStore.companyDefaults?.wage_rate ?? 0,
+            unit_rev: companyDefaultsStore.companyDefaults?.charge_out_rate ?? 0,
+          }
+        : { unit_rev: Number(line.unit_rev) }),
+    }
+    const optimistic: Partial<CostLine> = { ...patch }
+    autosave.scheduleSave(line, patch, optimistic)
+  }
+}
+```
+
+### 6. Update Props Interface
+
+#### Remove allowTypeEdit Prop
+
+```typescript
+const props = withDefaults(
+  defineProps<{
+    // ... other props
+    // Remove allowTypeEdit?: boolean
+    // ... rest
+  }>(),
+  {
+    // ... defaults
+    // Remove allowTypeEdit: true,
+  },
+)
+```
+
+### 7. Remove Old Logic
+
+#### Clean Up
+
+- Remove `canEditKindForLine()` function
+- Remove all dropdown menu logic in Type column
+- Remove `allowTypeEdit` prop handling
+
+## Testing Strategy
+
+### Test Cases
+
+1. **Item Selection:**
+
+   - Select regular stock item → kind = 'material'
+   - Select "Labour" item → kind = 'time'
+   - Verify unit_cost/unit_rev update correctly
+
+2. **Description Typing:**
+
+   - Type in description without item → kind = 'adjust'
+   - Verify kind changes appropriately
+
+3. **Autosave:**
+
+   - Changes to existing lines should autosave
+   - New lines should emit create when ready
+
+4. **Validations:**
+   - Ensure existing validations still work
+   - Kind changes don't break calculations
+
+## Files to Modify
+
+1. `src/views/purchasing/ItemSelect.vue` - Add mocked Labour item and kind emit
+2. `src/components/shared/SmartCostLinesTable.vue` - Main implementation
+
+## Backward Compatibility
+
+- All existing functionality preserved
+- Autosave and validation logic unchanged
+- Props interface updated (allowTypeEdit removed)
+- Type column becomes readonly but still displays correct information
+
+## Risk Assessment
+
+- **Low Risk**: Changes are additive and maintain existing behavior
+- **Testing Required**: Need to verify kind inference works in all scenarios
+- **Data Integrity**: Existing cost line data remains unchanged

--- a/src/components/job/JobQuoteTab.vue
+++ b/src/components/job/JobQuoteTab.vue
@@ -996,7 +996,6 @@ async function handleCreateFromEmpty(line: CostLine) {
       costLines.value[index] = created
     }
 
-    refreshQuoteData()
     emit('cost-line-changed')
     toast.success('Cost line created!')
     console.log('✅ Successfully created cost line:', created)

--- a/src/components/shared/SmartCostLinesTable.vue
+++ b/src/components/shared/SmartCostLinesTable.vue
@@ -24,6 +24,7 @@ import { Textarea } from '../ui/textarea'
 import ItemSelect from '../../views/purchasing/ItemSelect.vue'
 import type { DataTableRowContext } from '../../utils/data-table-types'
 import { toast } from 'vue-sonner'
+import { debugLog } from '../../utils/debug'
 import { HelpCircle, Trash2, Plus, AlertTriangle } from 'lucide-vue-next'
 import {
   Dialog,
@@ -105,7 +106,7 @@ const emit = defineEmits<{
 
 // Add logging to track emit calls
 const loggedEmit = (event: string, ...args: unknown[]) => {
-  console.log(`📤 SmartCostLinesTable emitting event: ${event}`, args)
+  debugLog(`📤 SmartCostLinesTable emitting event: ${event}`, args)
   return (emit as any)(event, ...args) // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
@@ -188,7 +189,7 @@ function updateLineKind(line: CostLine, newKind: KindOption) {
 
   // Save if line has real ID and meets baseline
   if (line.id && isLineReadyForSave(line)) {
-    console.log('Saving kind change:', line.id, newKind)
+    debugLog('Saving kind change:', line.id, newKind)
     const patch: PatchedCostLineCreateUpdate = {
       kind: newKind,
       ...(newKind === 'time'
@@ -288,8 +289,6 @@ function isNegativeStock(line: CostLine): boolean {
   if (!line?.id || !isStockLine(line)) return false
   return props.negativeStockIds?.includes(line.ext_refs?.stock_id as string) ?? false
 }
-
-// Removed unused function
 
 function canEditField(
   line: CostLine,
@@ -461,7 +460,7 @@ const columns = computed(() => {
                 'onUpdate:modelValue': async (val: string | null) => {
                   if (!enabled) return
                   if (val) {
-                    console.log('💾 Storing item selection:', { val, lineId: line.id })
+                    debugLog('💾 Storing item selection:', { val, lineId: line.id })
                     // Store full item data for display
                     if (val === '__labour__') {
                       selectedItemMap.set(line, {
@@ -469,15 +468,15 @@ const columns = computed(() => {
                         description: 'Labour',
                         item_code: 'LABOUR',
                       })
-                      console.log('👷 Stored labour item in selectedItemMap')
+                      debugLog('👷 Stored labour item in selectedItemMap')
                     } else {
                       // For regular items, we'll fetch the data below and update
                       selectedItemMap.set(line, { id: val, description: '', item_code: '' })
-                      console.log('📦 Stored placeholder for stock item in selectedItemMap')
+                      debugLog('📦 Stored placeholder for stock item in selectedItemMap')
                     }
                   } else {
                     selectedItemMap.set(line, null)
-                    console.log('🗑️ Cleared selectedItemMap for line')
+                    debugLog('🗑️ Cleared selectedItemMap for line')
                   }
 
                   // Infer kind based on selection
@@ -523,10 +522,10 @@ const columns = computed(() => {
                   try {
                     found = await api.purchasing_rest_stock_retrieve({ params: { id: val } })
                   } catch (error) {
-                    console.warn('Failed to fetch stock item details:', error)
+                    debugLog('Failed to fetch stock item details:', error)
                   }
                   if (found) {
-                    console.log('✅ API returned stock item:', {
+                    debugLog('✅ API returned stock item:', {
                       id: found.id,
                       item_code: found.item_code,
                       description: found.description,
@@ -539,7 +538,7 @@ const columns = computed(() => {
                       description: found.description || '',
                       item_code: found.item_code || '',
                     })
-                    console.log('💾 Updated selectedItemMap with full item data:', {
+                    debugLog('💾 Updated selectedItemMap with full item data:', {
                       id: val,
                       description: found.description || '',
                       item_code: found.item_code || '',
@@ -548,9 +547,8 @@ const columns = computed(() => {
                     if (line.quantity == null) Object.assign(line, { quantity: 1 })
                     if (kind !== 'time')
                       Object.assign(line, { unit_rev: apply(line).derived.unit_rev })
-                    // Don't create line immediately - let user fill other fields first
                   } else {
-                    console.log('❌ API did not return stock item for id:', val)
+                    debugLog('❌ API did not return stock item for id:', val)
                     Object.assign(line, { desc: '' })
                     Object.assign(line, { unit_cost: 0 })
                     selectedItemMap.set(line, null)
@@ -778,13 +776,13 @@ const columns = computed(() => {
 
                 // Create new line if it doesn't have an ID yet and meets baseline criteria
                 if (!line.id && isLineReadyForSave(line)) {
-                  console.log('Creating new line from unit_cost edit:', line)
+                  debugLog('Creating new line from unit_cost edit:', line)
                   maybeEmitCreate(line)
                   return
                 }
 
                 if (!line.id || !isLineReadyForSave(line)) {
-                  console.log('Skipping unit_cost save:', {
+                  debugLog('Skipping unit_cost save:', {
                     editable,
                     id: line.id,
                     ready: isLineReadyForSave(line),
@@ -792,7 +790,7 @@ const columns = computed(() => {
                   return
                 }
 
-                console.log('Saving unit_cost change:', line.id, line.unit_cost)
+                debugLog('Saving unit_cost change:', line.id, line.unit_cost)
                 // For material/adjust, unit_rev may be auto recalculated unless overridden
                 const derived = apply(line).derived
                 const patch: PatchedCostLineCreateUpdate = {
@@ -865,13 +863,13 @@ const columns = computed(() => {
 
                 // Create new line if it doesn't have an ID yet and meets baseline criteria
                 if (!line.id && isLineReadyForSave(line)) {
-                  console.log('Creating new line from unit_rev edit:', line)
+                  debugLog('Creating new line from unit_rev edit:', line)
                   maybeEmitCreate(line)
                   return
                 }
 
                 if (!line.id || !isLineReadyForSave(line)) {
-                  console.log('Skipping unit_rev save:', {
+                  debugLog('Skipping unit_rev save:', {
                     editable,
                     id: line.id,
                     ready: isLineReadyForSave(line),
@@ -879,7 +877,7 @@ const columns = computed(() => {
                   return
                 }
 
-                console.log('Saving unit_rev change:', line.id, line.unit_rev)
+                debugLog('Saving unit_rev change:', line.id, line.unit_rev)
                 const patch: PatchedCostLineCreateUpdate = {
                   unit_rev: Number(line.unit_rev ?? 0),
                 }
@@ -1061,7 +1059,7 @@ const columns = computed(() => {
                 e.stopPropagation()
                 if (disabled) return
 
-                console.log('🗑️ Delete button clicked for line:', {
+                debugLog('🗑️ Delete button clicked for line:', {
                   lineId: line.id,
                   rowIndex: row.index,
                   lineDesc: line.desc,
@@ -1074,18 +1072,18 @@ const columns = computed(() => {
                 if (!line.id) {
                   // Find the actual index in the original props.lines array
                   const actualIndex = props.lines.findIndex((l) => l === line)
-                  console.log('🔍 Looking for local line in props.lines:', {
+                  debugLog('🔍 Looking for local line in props.lines:', {
                     actualIndex,
                     foundLine: actualIndex >= 0 ? props.lines[actualIndex] : null,
                     searchedLine: line,
                   })
 
                   if (actualIndex >= 0) {
-                    console.log('✅ Emitting delete-line with actualIndex:', actualIndex)
+                    debugLog('✅ Emitting delete-line with actualIndex:', actualIndex)
                     loggedEmit('delete-line', actualIndex)
                   } else {
                     // This is the auto-generated empty line - don't delete it, just clear it
-                    console.log('⚠️ Auto-generated empty line - cannot delete, ignoring')
+                    debugLog('⚠️ Auto-generated empty line - cannot delete, ignoring')
                     return
                   }
                   return
@@ -1094,7 +1092,7 @@ const columns = computed(() => {
                 // For saved lines, ask for confirmation
                 const confirmed = window.confirm('Delete this line? This action cannot be undone.')
                 if (!confirmed) return
-                console.log('✅ Emitting delete-line with line.id:', line.id)
+                debugLog('✅ Emitting delete-line with line.id:', line.id)
                 loggedEmit('delete-line', line.id as string)
               },
             },
@@ -1138,11 +1136,11 @@ const { onKeydown } = useGridKeyboardNav({
   },
   deleteSelected: () => {
     const i = selectedRowIndex.value
-    console.log('⌨️ Keyboard delete triggered for selectedRowIndex:', i)
+    debugLog('⌨️ Keyboard delete triggered for selectedRowIndex:', i)
 
     if (i >= 0 && i < displayLines.value.length) {
       const line = displayLines.value[i]
-      console.log('🗑️ Keyboard delete for line:', {
+      debugLog('🗑️ Keyboard delete for line:', {
         lineId: line.id,
         selectedIndex: i,
         lineDesc: line.desc,
@@ -1150,21 +1148,21 @@ const { onKeydown } = useGridKeyboardNav({
       })
 
       if (line.id) {
-        console.log('✅ Keyboard emitting delete-line with line.id:', line.id)
+        debugLog('✅ Keyboard emitting delete-line with line.id:', line.id)
         loggedEmit('delete-line', line.id as string)
       } else {
         // Find the actual index in the original props.lines array
         const actualIndex = props.lines.findIndex((l) => l === line)
-        console.log('🔍 Keyboard looking for local line in props.lines:', {
+        debugLog('🔍 Keyboard looking for local line in props.lines:', {
           actualIndex,
           foundLine: actualIndex >= 0 ? props.lines[actualIndex] : null,
         })
 
         if (actualIndex >= 0) {
-          console.log('✅ Keyboard emitting delete-line with actualIndex:', actualIndex)
+          debugLog('✅ Keyboard emitting delete-line with actualIndex:', actualIndex)
           loggedEmit('delete-line', actualIndex)
         } else {
-          console.log('⚠️ Keyboard: Auto-generated empty line - cannot delete, ignoring')
+          debugLog('⚠️ Keyboard: Auto-generated empty line - cannot delete, ignoring')
         }
       }
     }

--- a/src/views/JobCreateView.vue
+++ b/src/views/JobCreateView.vue
@@ -577,8 +577,8 @@ const handleSubmit = async () => {
       }
       toast.success('Job created!')
       toast.dismiss('create-job')
-      // Redirect to quote tab for fixed price jobs, actual tab for time & materials
-      const defaultTab = formData.value.pricing_methodology === 'fixed_price' ? 'quote' : 'actual'
+      // Redirect to quote tab for fixed price jobs, estimate to t&m jobs
+      const defaultTab = formData.value.pricing_methodology === 'fixed_price' ? 'quote' : 'estimate'
       router.push({
         name: 'job-edit',
         params: { id: job_id },

--- a/src/views/JobCreateView.vue
+++ b/src/views/JobCreateView.vue
@@ -511,8 +511,10 @@ const handleSubmit = async () => {
 
     if (result.success && result.job_id) {
       const job_id = result.job_id
+      // Create estimate cost lines
+      const estimateLines = []
       try {
-        await costlineService.createCostLine(job_id, 'estimate', {
+        const materialLine = await costlineService.createCostLine(job_id, 'estimate', {
           kind: 'material',
           desc: 'Estimated materials',
           quantity: 1,
@@ -521,37 +523,67 @@ const handleSubmit = async () => {
             formData.value.estimatedMaterials! *
             (1 + companyDefaultsStore.companyDefaults?.materials_markup),
         })
+        estimateLines.push(materialLine)
       } catch (error: unknown) {
         toast.error((error as Error).message)
         debugLog('Failed to create material cost line:', error)
       }
       try {
-        await costlineService.createCostLine(job_id, 'estimate', {
+        const workshopTimeLine = await costlineService.createCostLine(job_id, 'estimate', {
           kind: 'time',
           desc: 'Estimated workshop time',
           quantity: formData.value.estimatedTime!,
           unit_cost: companyDefaultsStore.companyDefaults?.wage_rate,
           unit_rev: companyDefaultsStore.companyDefaults?.charge_out_rate,
         })
+        estimateLines.push(workshopTimeLine)
       } catch (error: unknown) {
         toast.error((error as Error).message)
         debugLog('Failed to create time cost line:', error)
       }
       try {
-        await costlineService.createCostLine(job_id, 'estimate', {
+        const officeTimeLine = await costlineService.createCostLine(job_id, 'estimate', {
           kind: 'time',
           desc: 'Estimated Office Time',
           quantity: calculateOfficeTimeQuantity(formData.value.estimatedTime ?? 0),
           unit_cost: companyDefaultsStore.companyDefaults?.wage_rate,
           unit_rev: companyDefaultsStore.companyDefaults?.charge_out_rate,
         })
+        estimateLines.push(officeTimeLine)
       } catch (error: unknown) {
         toast.error((error as Error).message)
         debugLog('Failed to create office time cost line:', error)
       }
+
+      // Automatically copy estimate lines to quote cost set only for fixed price jobs
+      if (formData.value.pricing_methodology === 'fixed_price') {
+        try {
+          for (const estimateLine of estimateLines) {
+            await costlineService.createCostLine(job_id, 'quote', {
+              kind: estimateLine.kind as 'material' | 'time' | 'adjust',
+              desc: estimateLine.desc || '',
+              quantity: estimateLine.quantity || 0,
+              unit_cost: estimateLine.unit_cost ?? 0,
+              unit_rev: estimateLine.unit_rev ?? 0,
+              ext_refs: (estimateLine.ext_refs as Record<string, unknown>) || {},
+              meta: (estimateLine.meta as Record<string, unknown>) || {},
+            })
+          }
+          debugLog('Successfully copied estimate lines to quote cost set')
+        } catch (error: unknown) {
+          toast.error('Failed to copy estimate to quote: ' + (error as Error).message)
+          debugLog('Failed to copy estimate lines to quote:', error)
+        }
+      }
       toast.success('Job created!')
       toast.dismiss('create-job')
-      router.push({ name: 'job-edit', params: { id: job_id } })
+      // Redirect to quote tab for fixed price jobs, actual tab for time & materials
+      const defaultTab = formData.value.pricing_methodology === 'fixed_price' ? 'quote' : 'actual'
+      router.push({
+        name: 'job-edit',
+        params: { id: job_id },
+        query: { new: 'true', tab: defaultTab },
+      })
     } else {
       throw new Error(String(result.error) || 'Failed to create job')
     }

--- a/src/views/JobView.vue
+++ b/src/views/JobView.vue
@@ -354,7 +354,15 @@ onMounted(async () => {
 })
 
 const { jobEvents, addEvent, loading: jobEventsLoading } = useJobEvents(jobId)
-const { activeTab, setTab } = useJobTabs('actual')
+// Check if this is a newly created job (redirected from creation)
+const isNewJob = computed(() => route.query.new === 'true')
+const queryTab = computed(() => route.query.tab as string)
+const defaultTab = computed(() => {
+  if (queryTab.value) return queryTab.value
+  if (isNewJob.value) return 'quote'
+  return 'actual'
+})
+const { activeTab, setTab } = useJobTabs(defaultTab.value)
 const notifications = useJobNotifications()
 
 const localJobName = ref('')

--- a/src/views/purchasing/ItemSelect.vue
+++ b/src/views/purchasing/ItemSelect.vue
@@ -1,4 +1,3 @@
-o
 <script setup lang="ts">
 import {
   Select,

--- a/src/views/purchasing/PurchaseOrderFormView.vue
+++ b/src/views/purchasing/PurchaseOrderFormView.vue
@@ -510,6 +510,9 @@ async function saveLines() {
     return
   }
 
+  // Take snapshot for rollback
+  const snapshot = JSON.parse(JSON.stringify(po.value.lines))
+
   linesToDelete.value = linesToDelete.value.filter((id) => {
     const l = po.value.lines.find((x: PurchaseOrderLine) => x.id === id)
     return l ? isValidLine(l) : true
@@ -637,7 +640,12 @@ async function saveLines() {
     toast.success('Lines saved')
   } catch (error) {
     debugLog('❌ Error saving lines:', error)
-    toast.error('Failed to save lines: ' + extractErrorMessage(error, 'Unknown error'))
+    // Rollback on error
+    po.value.lines = snapshot
+    toast.error(
+      'Failed to save lines. Changes have been reverted: ' +
+        extractErrorMessage(error, 'Unknown error'),
+    )
   }
 }
 


### PR DESCRIPTION
## 📝 Description

_Short explanation of what you’ve built and why._

## 🔗 Related Issue

Closes #[issue-number]

## 🚀 Changes

- Bullet-list of feature additions or fixes (e.g. extracted `useChat` composable, split `ChatHistory` and `ChatInput` components, added Pinia store).
- …

## ✅ Checklist

**Vue.js (Composition API)**

- [ ] Used Composition API (`<script setup>` & composables), no heavy logic in templates
- [ ] UI logic extracted to reusable composables (`useChat`, etc.)
- [ ] Components are focused & small (<200 LOC)
- [ ] Communication via `props` and `emit`, no direct parent/child ref duplication
- [ ] State management in Pinia; no ad-hoc reactive globals
- [ ] Routes/components lazy-loaded where appropriate

**Quality & Formatting**

- [ ] Passes Prettier (`npx prettier --check .`)
- [ ] Passes ESLint with zero warnings (`npx eslint . --ext .js,.ts,.vue`)
- [ ] Added JSDoc comments for all props and emitted events
- [ ] New or updated unit/E2E tests included
