### PR TITLE
Refactor/po lines table item select

### DIFF
--- a/src/components/job/JobActualTab.vue
+++ b/src/components/job/JobActualTab.vue
@@ -488,7 +488,7 @@ const showDetailedSummary = ref(false)
 
 // For actual tab specifics
 const blockedFieldsByKind = ref<Record<KindOption, string[]>>({
-  material: ['desc', 'quantity', 'unit_cost', 'unit_rev'],
+  material: ['quantity', 'unit_cost', 'unit_rev'], // Allow desc editing for material items
   adjust: [],
 })
 

--- a/src/components/job/JobActualTab.vue
+++ b/src/components/job/JobActualTab.vue
@@ -650,6 +650,8 @@ async function handleCreateLine(line: CostLine) {
         unit_rev: line.unit_rev,
         ext_refs: line.ext_refs || {},
         meta: { source: 'manual_adjustment' },
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
       }
 
       const created = await costlineService.createCostLine(props.jobId, 'actual', createPayload)

--- a/src/components/shared/SmartCostLinesTable.vue
+++ b/src/components/shared/SmartCostLinesTable.vue
@@ -539,6 +539,9 @@ const columns = computed(() => {
                       selectedItemMap.set(line, null)
                       return
                     }
+                  } else {
+                    // For other tabs (quote, estimate), also leave active mode to show item code
+                    selectedRowIndex.value = -1
                   }
 
                   let found = null

--- a/src/views/purchasing/ItemSelect.vue
+++ b/src/views/purchasing/ItemSelect.vue
@@ -58,9 +58,12 @@ onMounted(async () => {
 
 const filteredItems = computed(() => {
   const stockItems = store.items
-  const labourItem = props.tabKind === 'actual' ? [] : [mockedLabourItem.value]
+  // Only show labour items in job-related contexts (estimate, quote, actual tabs)
+  // Don't show labour in purchasing contexts
+  const labourItem =
+    props.tabKind === 'estimate' || props.tabKind === 'quote' ? [mockedLabourItem.value] : []
 
-  // Include LABOUR unless in actual tab, put it first
+  // Include LABOUR only for job contexts, put it first
   const allItems = [...labourItem, ...stockItems]
 
   if (!searchTerm.value) return allItems

--- a/src/views/purchasing/ItemSelect.vue
+++ b/src/views/purchasing/ItemSelect.vue
@@ -79,6 +79,18 @@ function formatCurrency(value: number): string {
     maximumFractionDigits: 2,
   }).format(value)
 }
+
+const displayPrice = (item: StockItem) => {
+  let price = '0.00'
+  if (item.id === '__labour__') {
+    price = formatCurrency(item.unit_rev || 0)
+  } else {
+    price = formatCurrency(
+      (item.unit_cost || 0) * (1 + (companyDefaultsStore.companyDefaults?.materials_markup || 0)),
+    )
+  }
+  return price
+}
 </script>
 
 <template>
@@ -158,14 +170,7 @@ function formatCurrency(value: number): string {
                 variant="secondary"
                 class="text-xs font-semibold"
               >
-                ${{
-                  i.id === '__labour__'
-                    ? formatCurrency(i.unit_rev || 0)
-                    : formatCurrency(
-                        (i.unit_cost || 0) *
-                          (1 + (companyDefaultsStore.companyDefaults?.materials_markup || 0)),
-                      )
-                }}
+                ${{ displayPrice(i) }}
               </Badge>
               <Badge v-else variant="secondary" class="text-xs"> No price </Badge>
 


### PR DESCRIPTION
## 📝 Description

_Short explanation of what you’ve built and why._

## 🔗 Related Issue

Closes #[issue-number]

## 🚀 Changes

- Bullet-list of feature additions or fixes (e.g. extracted `useChat` composable, split `ChatHistory` and `ChatInput` components, added Pinia store).
- …

## ✅ Checklist

**Vue.js (Composition API)**

- [ ] Used Composition API (`<script setup>` & composables), no heavy logic in templates
- [ ] UI logic extracted to reusable composables (`useChat`, etc.)
- [ ] Components are focused & small (<200 LOC)
- [ ] Communication via `props` and `emit`, no direct parent/child ref duplication
- [ ] State management in Pinia; no ad-hoc reactive globals
- [ ] Routes/components lazy-loaded where appropriate

**Quality & Formatting**

- [ ] Passes Prettier (`npx prettier --check .`)
- [ ] Passes ESLint with zero warnings (`npx eslint . --ext .js,.ts,.vue`)
- [ ] Added JSDoc comments for all props and emitted events
- [ ] New or updated unit/E2E tests included
