### PR TITLE
Refactor: improve cost lines table UX

### DIFF
--- a/src/components/job/JobActualTab.vue
+++ b/src/components/job/JobActualTab.vue
@@ -655,7 +655,13 @@ async function handleCreateLine(line: CostLine) {
       }
 
       const created = await costlineService.createCostLine(props.jobId, 'actual', createPayload)
-      costLines.value = costLines.value.map((l) => (l.id === line.id ? created : l)) // Replace temp
+      // Replace if the source line exists in parent's array, otherwise append (phantom row case)
+      const idx = costLines.value.findIndex((l) => l === line || l.id === line.id)
+      if (idx >= 0) {
+        costLines.value[idx] = created
+      } else {
+        costLines.value.push(created)
+      }
       toast.success('Adjustment added!')
       emit('cost-line-changed')
     } catch (error) {

--- a/src/components/shared/SmartCostLinesTable.vue
+++ b/src/components/shared/SmartCostLinesTable.vue
@@ -118,8 +118,9 @@ const showShortcuts = ref(false)
 const showDescModal = ref(false)
 const descModalLine = ref<CostLine | null>(null)
 const pendingFocusNewRow = ref(false)
+const openItemSelect = ref(false)
 
-// Focus first editable input after a row has been added
+// Focus on ItemSelect trigger and open popover after a row has been added
 watch(
   () => props.lines.length,
   async (len, prev) => {
@@ -127,10 +128,13 @@ watch(
       pendingFocusNewRow.value = false
       selectedRowIndex.value = len - 1
       await nextTick()
-      const el = containerRef.value?.querySelector(
-        'input:not([disabled]), textarea:not([disabled]), select:not([disabled])',
+      const itemTrigger = containerRef.value?.querySelector(
+        '.item-select-trigger',
       ) as HTMLElement | null
-      el?.focus()
+      if (itemTrigger) {
+        itemTrigger.focus()
+        openItemSelect.value = true
+      }
     }
   },
 )
@@ -467,6 +471,8 @@ const columns = computed(() => {
             return h('div', { class: 'col-item' }, [
               h(ItemSelect, {
                 modelValue: model,
+                open: openItemSelect.value,
+                'onUpdate:open': (val: boolean) => (openItemSelect.value = val),
                 disabled: !enabled,
                 lineKind: String(line.kind),
                 tabKind: props.tabKind,
@@ -1355,6 +1361,24 @@ const shortcutsTitle = computed(
 /* Row hover */
 .smart-costlines-table :deep(tbody tr:hover) {
   background-color: rgb(249, 250, 251);
+}
+
+/* Borders */
+.smart-costlines-table :deep(tbody tr) {
+  border: 1px solid #e5e7eb;
+  border-bottom: none;
+}
+
+.smart-costlines-table :deep(tbody tr:last-child) {
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.smart-costlines-table :deep(td) {
+  border-right: 1px solid #f3f4f6;
+}
+
+.smart-costlines-table :deep(td:last-child) {
+  border-right: none;
 }
 
 /* Numeric alignment */

--- a/src/composables/useCreateCostLineFromEmpty.ts
+++ b/src/composables/useCreateCostLineFromEmpty.ts
@@ -47,10 +47,13 @@ export function useCreateCostLineFromEmpty(options: UseCreateCostLineFromEmptyOp
 
       const created = await costlineService.createCostLine(jobId, costSetKind, createPayload)
 
-      // Replace the empty line with the created one
+      // Insert created line into costLines; replace if the source line exists, otherwise push (phantom row case)
       const index = costLines.value.findIndex((l) => l === line)
       if (index !== -1) {
         costLines.value[index] = created
+      } else {
+        // When creating from the table's phantom row (not present in costLines), append it
+        costLines.value.push(created)
       }
 
       toast.success('Cost line created!')

--- a/src/views/purchasing/ItemSelect.vue
+++ b/src/views/purchasing/ItemSelect.vue
@@ -125,7 +125,7 @@ const displayPrice = (item: StockItem) => {
       }
     "
   >
-    <SelectTrigger class="h-10">
+    <SelectTrigger class="h-10 item-select-trigger">
       <SelectValue :placeholder="'Select Item'" />
     </SelectTrigger>
 


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><h1 data-start="65" data-end="156">SmartCostLinesTable — Xero-style editing, phantom row, and keyboard-first flows (Phase 1)</h1>
<h2 data-start="158" data-end="168">Summary</h2>
<p data-start="169" data-end="498">This PR brings our quoting grid much closer to Xero’s Quotes/Invoices usability while keeping our domain model intact. We reduced clicks for the three primary actions (Material, Labour, Adjustment), enabled true keyboard-only entry, and added a “phantom” row so users can keep typing to add more lines without touching the mouse.</p>
<h2 data-start="500" data-end="506">Why</h2>
<ul data-start="507" data-end="706">
<li data-start="507" data-end="549">
<p data-start="509" data-end="549">Speed up line entry in Quotes/Estimates.</p>
</li>
<li data-start="550" data-end="588">
<p data-start="552" data-end="588">Make keyboard workflows first-class.</p>
</li>
<li data-start="589" data-end="636">
<p data-start="591" data-end="636">Reduce “modal friction” and redundant clicks.</p>
</li>
<li data-start="637" data-end="706">
<p data-start="639" data-end="706">Align interaction patterns with what users expect from Xero’s grid.</p>
</li>
</ul>
<h2 data-start="708" data-end="731">Scope (what changed)</h2>
<p data-start="732" data-end="816"><strong data-start="732" data-end="749">Frontend-only</strong> improvements to the SmartCostLinesTable component and its helpers:</p>
<ul data-start="817" data-end="1477">
<li data-start="817" data-end="874">
<p data-start="819" data-end="874">Auto-focus + auto-open Item dropdown after <strong data-start="862" data-end="873">Add row</strong>.</p>
</li>
<li data-start="875" data-end="960">
<p data-start="877" data-end="960"><strong data-start="877" data-end="892">Phantom row</strong> at the end; pressing Tab/Enter on the last cell creates a new line.</p>
</li>
<li data-start="961" data-end="1043">
<p data-start="963" data-end="1043"><strong data-start="963" data-end="993">Inline description editing</strong> by default (modal only when explicitly expanded).</p>
<li data-start="1315" data-end="1357">
<p data-start="1317" data-end="1357">Default <strong data-start="1325" data-end="1336">Qty = 1</strong> for Material/Labour.</p>
</li>
</ul>
<hr data-start="1607" data-end="1610">
<html>
<body>
<!--StartFragment--><h2>Before → After (measured click counts)</h2>

Task | Before | After
-- | -- | --
Add Material (inventory item) | 3 clicks | 2 clicks
Add Labour (“Labour” item) | 3 clicks | 2 clicks
Add Adjustment (no item, description only) | 3 clicks (modal) | 2 clicks (inline)


<!-- notionvc: 5adae9bb-cdb2-42b4-a36d-2a9591753381 --><!--EndFragment-->
</body>
</html>

</div></div>
<p data-start="1917" data-end="1937">Additional outcomes:</p>
<ul data-start="1938" data-end="2088">
<li data-start="1938" data-end="1994">
<p data-start="1940" data-end="1994"><strong data-start="1940" data-end="1957">Keyboard-only</strong> flow now viable for all three tasks.</p>
</li>
<li data-start="1995" data-end="2088">
<p data-start="1997" data-end="2088"><strong data-start="1997" data-end="2012">Phantom row</strong>: Tab/Enter at end of last row auto-creates a new row (no click on Add row).</p>
</li>
</ul>
<!--EndFragment-->
</body>
</html>