### PR TITLE
refactor(jobs): remove global currentJobId and related state from store

### DIFF
--- a/src/components/job/JobSettingsTab.vue
+++ b/src/components/job/JobSettingsTab.vue
@@ -959,10 +959,12 @@ const autosave = createJobAutosave({
             notes: notes || null,
           })
 
-          if (jobsStore.currentJob) {
+          // Update detailed job using explicit id (no global current job)
+          const existingDetailCurrent = jobsStore.getJobById(props.jobId)
+          if (existingDetailCurrent) {
             jobsStore.updateDetailedJob(props.jobId, {
               job: {
-                ...jobsStore.currentJob.job,
+                ...existingDetailCurrent.job,
                 description: desc || null,
                 delivery_date: delDate || null,
                 order_number: ordNum || null,

--- a/src/components/job/JobSettingsTab.vue
+++ b/src/components/job/JobSettingsTab.vue
@@ -255,7 +255,7 @@ const props = defineProps<{
 }>()
 
 const jobsStore = useJobsStore()
-const jobHeader = computed(() => jobsStore.currentHeader)
+const jobHeader = computed(() => jobsStore.headersById[props.jobId] ?? null)
 
 const jobData = ref<Job | null>(null)
 
@@ -266,9 +266,6 @@ onMounted(async () => {
     // Load job data if jobId exists
     (async () => {
       if (props.jobId) {
-        // Set current job ID in store for basic info to work
-        jobsStore.setCurrentJobId(props.jobId)
-
         // Load both header and basic info in parallel
         await Promise.all([
           // Load header data
@@ -360,10 +357,11 @@ async function loadBasicInfo() {
     }
 
     // Also update the detailed job in store if it exists
-    if (basicInfo && jobsStore.currentJob) {
+    const existingDetail = jobsStore.getJobById(props.jobId)
+    if (basicInfo && existingDetail) {
       jobsStore.updateDetailedJob(props.jobId, {
         job: {
-          ...jobsStore.currentJob.job,
+          ...existingDetail.job,
           description: basicInfo.description || null,
           delivery_date: basicInfo.delivery_date || null,
           order_number: basicInfo.order_number || null,
@@ -395,7 +393,7 @@ const dataReady = computed(
 
 // Use store for basic information
 const basicInfo = computed(() => {
-  return jobsStore.currentBasicInfo
+  return jobsStore.getBasicInfoById(props.jobId)
 })
 const basicInfoLoading = ref(false)
 

--- a/src/stores/jobs.ts
+++ b/src/stores/jobs.ts
@@ -57,6 +57,19 @@ export const useJobsStore = defineStore('jobs', () => {
     }
   })
 
+  // New getters to remove reliance on global currentJobId
+  const getHeaderById = computed(() => {
+    return (id: string): JobHeaderResponse | null => {
+      return headersById.value[id] || null
+    }
+  })
+
+  const getBasicInfoById = computed(() => {
+    return (id: string): JobBasicInfo | null => {
+      return basicInfoById.value[id] || null
+    }
+  })
+
   const setDetailedJob = (jobDetail: JobDetail): void => {
     if (!jobDetail) {
       debugLog('🚨 Store - setDetailedJob called with null/undefined jobDetail')
@@ -347,6 +360,10 @@ export const useJobsStore = defineStore('jobs', () => {
     allKanbanJobs,
     getJobById,
     getKanbanJobById,
+    getHeaderById,
+    getBasicInfoById,
+    getHeaderById,
+    getBasicInfoById,
 
     setDetailedJob,
     updateDetailedJob,

--- a/src/stores/jobs.ts
+++ b/src/stores/jobs.ts
@@ -21,25 +21,9 @@ export const useJobsStore = defineStore('jobs', () => {
   const kanbanJobs = ref<Record<string, KanbanJobUI>>({})
   const headersById = ref<Record<string, JobHeaderResponse>>({})
   const basicInfoById = ref<Record<string, JobBasicInfo>>({})
-  const currentJobId = ref<string | null>(null)
   const isLoadingJob = ref(false)
   const isLoadingKanban = ref(false)
   const currentContext = ref<'kanban' | 'detail' | null>(null)
-
-  const currentJob = computed(() => {
-    if (!currentJobId.value) return null
-    return detailedJobs.value[currentJobId.value] || null
-  })
-
-  const currentHeader = computed(() => {
-    if (!currentJobId.value) return null
-    return headersById.value[currentJobId.value] || null
-  })
-
-  const currentBasicInfo = computed(() => {
-    if (!currentJobId.value) return null
-    return basicInfoById.value[currentJobId.value] || null
-  })
 
   const allKanbanJobs = computed(() => {
     return Object.values(kanbanJobs.value)
@@ -194,10 +178,6 @@ export const useJobsStore = defineStore('jobs', () => {
     }
   }
 
-  const setCurrentJobId = (jobId: string | null): void => {
-    currentJobId.value = jobId
-  }
-
   const setCurrentContext = (context: 'kanban' | 'detail' | null): void => {
     currentContext.value = context
   }
@@ -212,7 +192,6 @@ export const useJobsStore = defineStore('jobs', () => {
 
   const clearDetailedJobs = (): void => {
     detailedJobs.value = {}
-    currentJobId.value = null
   }
 
   const clearKanbanJobs = (): void => {
@@ -349,19 +328,13 @@ export const useJobsStore = defineStore('jobs', () => {
     kanbanJobs,
     headersById,
     basicInfoById,
-    currentJobId,
     isLoadingJob,
     isLoadingKanban,
     currentContext,
 
-    currentJob,
-    currentHeader,
-    currentBasicInfo,
     allKanbanJobs,
     getJobById,
     getKanbanJobById,
-    getHeaderById,
-    getBasicInfoById,
     getHeaderById,
     getBasicInfoById,
 
@@ -372,7 +345,6 @@ export const useJobsStore = defineStore('jobs', () => {
     setKanbanJob,
     updateKanbanJob,
     removeKanbanJob,
-    setCurrentJobId,
     setCurrentContext,
     setLoadingJob,
     setLoadingKanban,

--- a/src/stores/jobs.ts
+++ b/src/stores/jobs.ts
@@ -41,7 +41,6 @@ export const useJobsStore = defineStore('jobs', () => {
     }
   })
 
-  // New getters to remove reliance on global currentJobId
   const getHeaderById = computed(() => {
     return (id: string): JobHeaderResponse | null => {
       return headersById.value[id] || null

--- a/src/views/JobView.vue
+++ b/src/views/JobView.vue
@@ -333,11 +333,9 @@ const jobId = computed(() => route.params.id as string)
 const loadingJob = ref(false)
 
 // Use store for header (single source of truth)
-const jobHeader = computed(() => jobsStore.currentHeader)
+const jobHeader = computed(() => jobsStore.headersById[jobId.value] ?? null)
 
 onMounted(async () => {
-  jobsStore.setCurrentJobId(jobId.value)
-
   loadingJob.value = true
   try {
     const headerResponse = await api.job_rest_jobs_header_retrieve({


### PR DESCRIPTION
feat(jobs): add ID-based getters for job headers and basic info
fix(jobs): update JobSettingsTab and JobView to use ID-based job data access
refactor(jobs): remove headerToPartialJob mapping in useJobHeaderAutosave
fix(jobs): filter patch payload in useJobHeaderAutosave to only allow header fields
fix(jobs): improve reorderJob defensive guards and logging in jobService
fix(jobs): refine targetColumnJobs extraction in useOptimizedDragAndDrop
style(jobs): add debug logging to jobService for API calls

This refactoring removes the reliance on a global `currentJobId` in the `jobs` store, which was a source of potential bugs and made components less reusable. Instead, components now explicitly pass `jobId` to retrieve specific job data. New ID-based getters (`getHeaderById`, `getBasicInfoById`) have been added to the store to facilitate this.

The `JobSettingsTab` and `JobView` components have been updated to use these new getters, ensuring they fetch data relevant to their specific `jobId` prop or route parameter.

In `useJobHeaderAutosave`, the `headerToPartialJob` mapping was removed as it was creating a full `Job` object from a `JobHeaderResponse` and then applying a patch, which could lead to unintended overwrites of basic info fields. Now, the patch payload is strictly filtered to only include header-related fields, preventing accidental updates to other job details. This ensures that header autosave only modifies header data.

The `jobService.reorderJob` function now includes defensive guards to prevent self-referencing or contradictory `beforeId` and `afterId` values, making the reordering logic more robust. Debug logging has been added to various `jobService` methods to provide better visibility into API call requests, responses, and errors.

Finally, `useOptimizedDragAndDrop` now more accurately extracts `targetColumnJobs` by specifically querying for `.job-card` elements, ensuring that the indices align correctly with Sortable.js's `newIndex` and preventing issues with non-job-card elements in the column.