### PR TITLE
fix: remove weekends from KPI calendar display

### DIFF
--- a/src/components/kpi/KPICalendar.vue
+++ b/src/components/kpi/KPICalendar.vue
@@ -53,7 +53,7 @@ defineEmits<{
   dayClick: [day: DayKPI]
 }>()
 
-const dayHeaders = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+const dayHeaders = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri']
 
 const monthYear = computed(() => {
   const date = new Date(props.year, props.month - 1)
@@ -73,11 +73,14 @@ const paddingDays = computed(() => {
   const firstDay = new Date(props.year, props.month - 1, 1)
   const dayOfWeek = firstDay.getDay()
 
-  return dayOfWeek === 0 ? 6 : dayOfWeek - 1
+  // Convert to Monday-based (0 = Mon, 6 = Sun)
+  // Skip weekends entirely
+  if (dayOfWeek === 0 || dayOfWeek === 6) return 0
+  return dayOfWeek - 1
 })
 
 const remainingDays = computed(() => {
-  const totalCells = 42
+  const totalCells = 35 // 5 days × 7 weeks max
   const usedCells = paddingDays.value + calendarDays.value.length
   return totalCells - usedCells
 })
@@ -103,7 +106,7 @@ const remainingDays = computed(() => {
 }
 
 .kpi-calendar__day-headers {
-  @apply grid grid-cols-6 gap-1 mb-1;
+  @apply grid grid-cols-5 gap-1 mb-1;
 }
 
 .kpi-calendar__day-header {
@@ -112,7 +115,7 @@ const remainingDays = computed(() => {
 }
 
 .kpi-calendar__days {
-  @apply grid grid-cols-6 gap-1;
+  @apply grid grid-cols-5 gap-1;
 }
 
 .kpi-calendar__day-empty {


### PR DESCRIPTION
Updates KPI calendar to show only weekdays (Mon-Fri) instead of including Saturday. Adjusts grid layout from 6 to 5 columns and updates padding calculation to skip weekends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 📝 Description

_Short explanation of what you’ve built and why._

## 🔗 Related Issue

Closes #[issue-number]

## 🚀 Changes

- Bullet-list of feature additions or fixes (e.g. extracted `useChat` composable, split `ChatHistory` and `ChatInput` components, added Pinia store).
- …

## ✅ Checklist

**Vue.js (Composition API)**

- [ ] Used Composition API (`<script setup>` & composables), no heavy logic in templates
- [ ] UI logic extracted to reusable composables (`useChat`, etc.)
- [ ] Components are focused & small (<200 LOC)
- [ ] Communication via `props` and `emit`, no direct parent/child ref duplication
- [ ] State management in Pinia; no ad-hoc reactive globals
- [ ] Routes/components lazy-loaded where appropriate

**Quality & Formatting**

- [ ] Passes Prettier (`npx prettier --check .`)
- [ ] Passes ESLint with zero warnings (`npx eslint . --ext .js,.ts,.vue`)
- [ ] Added JSDoc comments for all props and emitted events
- [ ] New or updated unit/E2E tests included
