### PR TITLE
fix: use console.error for critical errors in JobHistoryTab

### DIFF
--- a/src/components/job/JobHistoryTab.vue
+++ b/src/components/job/JobHistoryTab.vue
@@ -187,7 +187,6 @@ import { api } from '@/api/client'
 import { schemas } from '@/api/generated/api'
 import type { z } from 'zod'
 import { toast } from 'vue-sonner'
-import { debugLog } from '../../utils/debug'
 
 type JobEventCreateRequest = z.infer<typeof schemas.JobEventCreateRequest>
 type JobEventCreateResponse = z.infer<typeof schemas.JobEventCreateResponse>
@@ -255,7 +254,7 @@ async function loadTimeline() {
     timelineEntries.value = response.timeline || []
   } catch (e) {
     toast.error('Failed to load timeline')
-    debugLog('Failed to load timeline:', e)
+    console.error('Failed to load timeline:', e)
     timelineEntries.value = []
   } finally {
     isLoading.value = false


### PR DESCRIPTION
Replaced debugLog with console.error for:
- Failed to load timeline
- Failed to add event

These are critical failures that should always be visible in production logs, not just in development mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 📝 Description

_Short explanation of what you’ve built and why._

## 🔗 Related Issue

Closes #[issue-number]

## 🚀 Changes

- Bullet-list of feature additions or fixes (e.g. extracted `useChat` composable, split `ChatHistory` and `ChatInput` components, added Pinia store).
- …

## ✅ Checklist

**Vue.js (Composition API)**

- [ ] Used Composition API (`<script setup>` & composables), no heavy logic in templates
- [ ] UI logic extracted to reusable composables (`useChat`, etc.)
- [ ] Components are focused & small (<200 LOC)
- [ ] Communication via `props` and `emit`, no direct parent/child ref duplication
- [ ] State management in Pinia; no ad-hoc reactive globals
- [ ] Routes/components lazy-loaded where appropriate

**Quality & Formatting**

- [ ] Passes Prettier (`npx prettier --check .`)
- [ ] Passes ESLint with zero warnings (`npx eslint . --ext .js,.ts,.vue`)
- [ ] Added JSDoc comments for all props and emitted events
- [ ] New or updated unit/E2E tests included
