### PR TITLE
fix(purchasing): reload existing allocations after status change

### DIFF
--- a/src/views/purchasing/PurchaseOrderFormView.vue
+++ b/src/views/purchasing/PurchaseOrderFormView.vue
@@ -341,6 +341,7 @@ async function saveSummary() {
   await store.patch(orderId, updateData)
   toast.success('Summary saved')
   await load()
+  await loadExistingAllocations()
 }
 
 const handleAddLineEvent = () => {


### PR DESCRIPTION
## Summary

After a purchase order summary is saved, the existing allocations need to be reloaded to ensure the UI displays the correct and current state of allocations, to ensure reactivity between operations.