### PR TITLE
feat(job): add print delivery docket functionality

### DIFF
--- a/schema.yml
+++ b/schema.yml
@@ -288,11 +288,10 @@ paths:
   /accounts/api/token/:
     post:
       operationId: accounts_api_token_create
-      description: 'Obtains JWT tokens for authentication. When ENABLE_JWT_AUTH=True,
-        tokens are set as httpOnly cookies, and the response body will be an empty
-        object (schema: EmptySerializer). Otherwise, the response body will contain
-        the tokens (schema: TokenObtainPairResponseSerializer). Also checks if the
-        user needs to reset their password.'
+      description: Obtains JWT tokens for authentication. When ENABLE_JWT_AUTH=True,
+        tokens are set as httpOnly cookies and the response body will be an empty
+        object. Otherwise, the response body will contain the tokens. Also checks
+        if the user needs to reset their password.
       tags:
         - accounts
       requestBody:
@@ -312,23 +311,16 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: {}
-                description: Unspecified response body
+                $ref: '#/components/schemas/TokenObtainPairResponse'
           description: ''
         '401':
-          content:
-            application/json:
-              schema:
-                description: Authentication failed due to invalid credentials
-          description: ''
+          description: No response body
   /accounts/api/token/refresh/:
     post:
       operationId: accounts_api_token_refresh_create
-      description: 'Refreshes the JWT access token using a refresh token. When ENABLE_JWT_AUTH=True,
+      description: Refreshes the JWT access token using a refresh token. When ENABLE_JWT_AUTH=True,
         the new access token is set as an httpOnly cookie and removed from the JSON
-        response (schema: EmptySerializer). Otherwise, the response contains the new
-        access token (schema: TokenRefreshResponseSerializer).'
+        response. Otherwise, the response contains the new access token.
       tags:
         - accounts
       requestBody:
@@ -348,16 +340,10 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: {}
-                description: Unspecified response body
+                $ref: '#/components/schemas/TokenRefreshResponse'
           description: ''
         '401':
-          content:
-            application/json:
-              schema:
-                description: Authentication failed due to invalid refresh token
-          description: ''
+          description: No response body
   /accounts/api/token/verify/:
     post:
       operationId: accounts_api_token_verify_create
@@ -3424,6 +3410,29 @@ paths:
               schema:
                 $ref: '#/components/schemas/JobRestErrorResponse'
           description: ''
+  /job/rest/jobs/{job_id}/delivery-docket/:
+    get:
+      operationId: generateDeliveryDocketRest
+      description: Generate a delivery docket PDF for a job and save it as a JobFile
+      parameters:
+        - in: path
+          name: job_id
+          schema:
+            type: string
+            format: uuid
+          required: true
+      tags:
+        - job
+      security:
+        - cookieAuth: []
+        - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkshopPDFResponse'
+          description: ''
   /job/rest/jobs/{job_id}/delta-rejections/:
     get:
       operationId: job_rest_job_delta_rejections_list
@@ -5037,14 +5046,6 @@ paths:
                 items:
                   $ref: '#/components/schemas/PurchaseOrderList'
           description: ''
-        '400':
-          content:
-            application/json:
-              schema:
-                type: object
-                additionalProperties: {}
-                description: Unspecified response body
-          description: ''
     post:
       operationId: purchasing_rest_purchase_orders_create
       description: Create new purchase order.
@@ -5183,14 +5184,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AllocationDetailsResponse'
-          description: ''
-        '404':
-          content:
-            application/json:
-              schema:
-                type: object
-                additionalProperties: {}
-                description: Unspecified response body
           description: ''
   /purchasing/rest/purchase-orders/{po_id}/lines/{line_id}/allocations/delete/:
     post:
@@ -12203,6 +12196,28 @@ components:
         - unit_rev
         - updated_at
         - wage_rate
+    TokenObtainPairResponse:
+      type: object
+      description: |-
+        Serializer for the response of the token obtain pair view.
+        This is used to properly document the API response schema.
+
+        All fields are optional because when ENABLE_JWT_AUTH=True,
+        tokens are set as httpOnly cookies and removed from the JSON response.
+      properties:
+        access:
+          type: string
+          description: JWT access token (only present when not using httpOnly cookies)
+        refresh:
+          type: string
+          description: JWT refresh token (only present when not using httpOnly cookies)
+        password_needs_reset:
+          type: boolean
+          description: Indicates if the user needs to reset their password
+        password_reset_url:
+          type: string
+          format: uri
+          description: URL to reset password if needed
     TokenRefresh:
       type: object
       properties:
@@ -12215,6 +12230,19 @@ components:
       required:
         - access
         - refresh
+    TokenRefreshResponse:
+      type: object
+      description: |-
+        Serializer for the response of the token refresh view.
+        This is used to properly document the API response schema.
+
+        The access field is optional because when ENABLE_JWT_AUTH=True,
+        the token is set as an httpOnly cookie and removed from the JSON response.
+      properties:
+        access:
+          type: string
+          description: New JWT access token (only present when not using httpOnly
+            cookies)
     TokenVerify:
       type: object
       properties:

--- a/src/services/job.service.ts
+++ b/src/services/job.service.ts
@@ -274,6 +274,18 @@ export const jobService = {
     }
   },
 
+  async getDeliveryDocket(jobId: string): Promise<Blob> {
+    try {
+      const response = await axios.get(`/job/rest/jobs/${jobId}/delivery-docket/`, {
+        responseType: 'blob',
+      })
+      return response.data
+    } catch (error) {
+      console.error('Error fetching delivery docket:', error)
+      throw error
+    }
+  },
+
   // Settings
   getCompanyDefaults(): Promise<CompanyDefaults> {
     return api.api_company_defaults_retrieve()

--- a/src/views/JobView.vue
+++ b/src/views/JobView.vue
@@ -248,6 +248,12 @@
             >
               <Download class="w-4 h-4 mr-1" /> Download Sheet
             </button>
+            <button
+              class="inline-flex items-center justify-center h-9 px-3 rounded-md bg-gray-100 text-gray-700 border border-gray-300 text-sm font-medium hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-gray-500"
+              @click="printDeliveryDocket"
+            >
+              <Printer class="w-4 h-4 mr-1" /> Print Docket
+            </button>
           </div>
         </div>
       </div>
@@ -620,6 +626,28 @@ async function downloadJobSheet() {
   } catch (error) {
     toast.error('Error generating PDF for download')
     debugLog('Error downloading job sheet:', error)
+  }
+}
+
+async function printDeliveryDocket() {
+  if (!jobDataWithPaid.value?.id) {
+    toast.error('Job ID not available')
+    return
+  }
+  try {
+    const blob = await jobService.getDeliveryDocket(jobDataWithPaid.value.id)
+    const pdfUrl = URL.createObjectURL(blob)
+    const win = window.open(pdfUrl, '_blank')
+    if (win) {
+      win.addEventListener('load', () => {
+        win.print()
+      })
+    } else {
+      toast.error('Failed to open print window. Please check popup blocker settings.')
+    }
+  } catch (error) {
+    toast.error('Error generating delivery docket for printing')
+    debugLog('Error printing delivery docket:', error)
   }
 }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -36,7 +36,7 @@ export default defineConfig(({ mode }) => {
             },
           }
         : {}),
-      port: 5174,
+      port: 5173,
     },
   }
 })


### PR DESCRIPTION
Add delivery docket printing feature following the existing workshop PDF pattern:
- Add getDeliveryDocket service method to fetch delivery docket PDF from backend
- Add printDeliveryDocket function to open print dialog
- Add "Print Docket" button in job header next to existing print buttons
- Update schema and API types for delivery-docket endpoint

fix(vite): revert dev server port back to 5173

Revert accidental port change from 5173 to 5174 introduced in previous commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 📝 Description

_Short explanation of what you’ve built and why._

## 🔗 Related Issue

Closes #[issue-number]

## 🚀 Changes

- Bullet-list of feature additions or fixes (e.g. extracted `useChat` composable, split `ChatHistory` and `ChatInput` components, added Pinia store).
- …

## ✅ Checklist

**Vue.js (Composition API)**

- [ ] Used Composition API (`<script setup>` & composables), no heavy logic in templates
- [ ] UI logic extracted to reusable composables (`useChat`, etc.)
- [ ] Components are focused & small (<200 LOC)
- [ ] Communication via `props` and `emit`, no direct parent/child ref duplication
- [ ] State management in Pinia; no ad-hoc reactive globals
- [ ] Routes/components lazy-loaded where appropriate

**Quality & Formatting**

- [ ] Passes Prettier (`npx prettier --check .`)
- [ ] Passes ESLint with zero warnings (`npx eslint . --ext .js,.ts,.vue`)
- [ ] Added JSDoc comments for all props and emitted events
- [ ] New or updated unit/E2E tests included
