### PR TITLE
fix: unit cost not editable on item selection

### DIFF
--- a/src/components/purchasing/PoLinesTable.vue
+++ b/src/components/purchasing/PoLinesTable.vue
@@ -312,7 +312,7 @@ const columns = computed(() =>
           step: '0.01',
           min: '0',
           modelValue: row.original.unit_cost ?? '',
-          disabled: !!row.original.item_code || row.original.price_tbc || isColumnDisabled.value,
+          disabled: row.original.price_tbc || isColumnDisabled.value,
           class: 'w-24 text-right',
           onClick: (e: Event) => e.stopPropagation(),
           'onUpdate:modelValue': isColumnDisabled.value


### PR DESCRIPTION
Remove item_code from unit cost input disable condition

The `unit_cost` input field was previously disabled if an `item_code` was present. This change removes that condition, allowing users to modify the unit cost for line items even when an `item_code` is associated. The disabling logic now correctly relies only on `price_tbc` or the general `isColumnDisabled` flag, ensuring flexibility in price adjustments.
