### PR TITLE
fix(kanban): correctly display search results when search query is active

### DIFF
--- a/src/composables/useOptimizedKanban.ts
+++ b/src/composables/useOptimizedKanban.ts
@@ -226,7 +226,7 @@ export function useOptimizedKanban(onJobsLoaded?: () => void) {
 
   // Get jobs for a specific column with staff filtering
   const getJobsByStatus = computed(() => (columnId: string) => {
-    if (filteredJobs.value.length > 0) {
+    if (filteredJobs.value.length > 0 || searchQuery.value.trim() !== '') {
       // When searching, group filteredJobs by column
       const grouped: Record<string, KanbanJob[]> = {}
       filteredJobs.value.forEach((job) => {


### PR DESCRIPTION
This change ensures that the `getJobsByStatus` computed property always uses the `filteredJobs` when a search query is active, even if the search yields no results. Previously, if a search query was active but `filteredJobs` was empty, the component would incorrectly revert to displaying all jobs instead of showing an empty search result.
