### PR TITLE
feat(purchasing): Add purchase order email and PDF generation endpoints

### DIFF
--- a/schema.yml
+++ b/schema.yml
@@ -3016,16 +3016,11 @@ paths:
         content:
           multipart/form-data:
             schema:
-              type: object
-              properties:
-                files:
-                  type: array
-                  items:
-                    type: string
-                    format: binary
-                  description: Files to upload
-              required:
-                - files
+              $ref: '#/components/schemas/JobFileUploadRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/JobFileUploadRequest'
+        required: true
       security:
         - cookieAuth: []
         - {}
@@ -4198,6 +4193,46 @@ paths:
               schema:
                 $ref: '#/components/schemas/AllocationDetailsResponse'
           description: ''
+  /purchasing/rest/purchase-orders/{po_id}/email/:
+    post:
+      operationId: getPurchaseOrderEmail
+      description: Generate email data for the specified purchase order.
+      parameters:
+        - in: path
+          name: po_id
+          schema:
+            type: string
+            format: uuid
+          required: true
+      tags:
+        - purchasing
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PurchaseOrderEmailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PurchaseOrderEmailRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PurchaseOrderEmailRequest'
+      security:
+        - cookieAuth: []
+        - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PurchaseOrderEmailResponse'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PurchaseOrderEmailResponse'
+          description: ''
   /purchasing/rest/purchase-orders/{po_id}/lines/{line_id}/allocations/delete/:
     post:
       operationId: deleteAllocation
@@ -4245,6 +4280,29 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AllocationDeleteResponse'
+          description: ''
+  /purchasing/rest/purchase-orders/{po_id}/pdf/:
+    get:
+      operationId: getPurchaseOrderPDF
+      description: Generate and download PDF for the specified purchase order.
+      parameters:
+        - in: path
+          name: po_id
+          schema:
+            type: string
+            format: uuid
+          required: true
+      tags:
+        - purchasing
+      security:
+        - cookieAuth: []
+        - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PurchaseOrderPDFResponse'
           description: ''
   /purchasing/rest/stock/:
     get:
@@ -5009,12 +5067,12 @@ components:
       properties:
         allocation_type:
           allOf:
-            - $ref: '#/components/schemas/TypeC98Enum'
+            - $ref: '#/components/schemas/AllocationTypeEnum'
           description: |-
             Type of allocation to delete
 
-            * `stock` - Stock
             * `job` - Job
+            * `stock` - Stock
         allocation_id:
           type: string
           format: uuid
@@ -5048,7 +5106,7 @@ components:
       description: Serializer for allocation details response
       properties:
         type:
-          $ref: '#/components/schemas/TypeC98Enum'
+          $ref: '#/components/schemas/TypeD09Enum'
         id:
           type: string
           format: uuid
@@ -5125,6 +5183,14 @@ components:
         - job_name
         - quantity
         - type
+    AllocationTypeEnum:
+      enum:
+        - job
+        - stock
+      type: string
+      description: |-
+        * `job` - Job
+        * `stock` - Stock
     AppError:
       type: object
       description: Basic serializer for AppError instances.
@@ -7571,6 +7637,22 @@ components:
         - errors
         - status
         - uploaded
+    JobFileUploadRequest:
+      type: object
+      description: Serializer for job file upload requests.
+      properties:
+        files:
+          type: array
+          items:
+            type: string
+            format: uri
+          description: Files to upload
+        print_on_jobsheet:
+          type: boolean
+          default: true
+          description: Flag indicating whether the file should print on the jobsheet.
+      required:
+        - files
     JobFileUploadSuccessResponse:
       type: object
       description: Serializer for successful file upload response.
@@ -9681,6 +9763,32 @@ components:
         * `partially_received` - Partially Received
         * `fully_received` - Fully Received
         * `deleted` - Deleted
+    PurchaseOrderEmailRequest:
+      type: object
+      description: Serializer for purchase order email generation request
+      properties:
+        recipient_email:
+          type: string
+          format: email
+        message:
+          type: string
+          maxLength: 1000
+    PurchaseOrderEmailResponse:
+      type: object
+      description: Serializer for purchase order email generation response
+      properties:
+        success:
+          type: boolean
+        email_subject:
+          type: string
+        email_body:
+          type: string
+        pdf_url:
+          type: string
+        message:
+          type: string
+      required:
+        - success
     PurchaseOrderLine:
       type: object
       description: Serializer for PurchaseOrderLine model.
@@ -9885,6 +9993,14 @@ components:
         - status
         - supplier
         - supplier_id
+    PurchaseOrderPDFResponse:
+      type: object
+      description: Serializer for purchase order PDF generation response
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
     PurchaseOrderUpdate:
       type: object
       description: Serializer for updating purchase orders.
@@ -11210,6 +11326,14 @@ components:
       description: |-
         * `stock` - Stock
         * `job` - Job
+    TypeD09Enum:
+      enum:
+        - job
+        - stock
+      type: string
+      description: |-
+        * `job` - Job
+        * `stock` - Stock
     UploadedFile:
       type: object
       description: Serializer for file upload response.

--- a/src/stores/purchaseOrderStore.ts
+++ b/src/stores/purchaseOrderStore.ts
@@ -116,8 +116,8 @@ export const usePurchaseOrderStore = defineStore('purchaseOrders', () => {
     }
 
     try {
-      // First, try the standard endpoint
-      const response = await axios.get(`/purchasing/api/purchase-orders/${id}/pdf/`, {
+      // Use the updated endpoint
+      const response = await axios.get(`/purchasing/rest/purchase-orders/${id}/pdf/`, {
         responseType: 'blob',
       })
 
@@ -134,9 +134,9 @@ export const usePurchaseOrderStore = defineStore('purchaseOrders', () => {
     }
 
     try {
-      const response = await api.purchasing_api_purchase_orders_email_create(
+      const response = await api.getPurchaseOrderEmail(
         {}, // Empty body as required by the schema
-        { params: { purchase_order_id: id } },
+        { params: { po_id: id } },
       )
       return response
     } catch (err) {


### PR DESCRIPTION
Add `/purchasing/rest/purchase-orders/{po_id}/email/` endpoint to generate and retrieve purchase order email data. Add
`/purchasing/rest/purchase-orders/{po_id}/pdf/` endpoint to generate and download purchase order PDFs. Update `uploadJobFiles` endpoint to reference a dedicated `JobFileUploadRequest` schema for consistency. Refactor `AllocationDeleteRequest` and `AllocationDetailsResponse` to use new `AllocationTypeEnum` for clarity. Correct indentation across various sections of the OpenAPI schema for improved readability and adherence to YAML standards.
These changes introduce new capabilities for managing purchase orders, allowing users to generate and send emails and download PDFs directly from the system. Standardizing the file upload schema improves maintainability. The indentation fixes enhance the overall quality and readability of the OpenAPI specification. The enum updates ensure accurate and consistent type definitions for allocation-related operations.

feat(schema.yml): add JobFileUploadRequest schema for file uploads feat(schema.yml): add PurchaseOrderEmailRequest and PurchaseOrderEmailResponse schemas feat(schema.yml): add PurchaseOrderPDFResponse schema for PDF generation feat(schema.yml): add TypeD09Enum for job and stock types style(schema.yml): reformat required fields to align with OpenAPI specification This commit introduces new schemas for job file uploads, purchase order email generation and responses, and purchase order PDF generation. It also adds a new enum `TypeD09Enum` to represent job and stock types. The formatting of `required` fields across various schemas has been standardized for better readability and adherence to OpenAPI specification.

feat(api): update generated API client with new schemas and endpoints
refactor(api): rename `uploadJobFiles_Body` to `JobFileUploadRequest` for clarity
refactor(api): rename `TypeC98Enum` to `TypeD09Enum` and `AllocationTypeEnum` for clarity

This commit updates the generated API client to include new schemas and endpoints related to purchase orders and job file uploads. The `uploadJobFiles_Body` schema has been renamed to `JobFileUploadRequest` to better reflect its purpose and improve readability. The `TypeC98Enum` has been renamed to `TypeD09Enum` and a new `AllocationTypeEnum` has been introduced, which improves the clarity and consistency of type definitions. New endpoints for emailing and generating PDFs for purchase orders have been added, enhancing the functionality of the purchasing module. The `purchaseOrderStore` has been updated to use the new API endpoints for PDF generation and email functionality, ensuring the application leverages the latest API features.