### PR TITLE
feat: add client contact edit/delete and consolidate formatting utili…

### DIFF
--- a/schema.yml
+++ b/schema.yml
@@ -67,6 +67,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/JobAgingResponse'
           description: ''
+  /accounting/api/reports/job-movement/:
+    get:
+      operationId: accounting_api_reports_job_movement_retrieve
+      description: Handle GET request for job movement metrics.
+      tags:
+        - accounting
+      security:
+        - cookieAuth: []
+        - {}
+      responses:
+        '200':
+          description: No response body
   /accounting/api/reports/profit-and-loss/:
     get:
       operationId: accounting_api_reports_profit_and_loss_retrieve
@@ -1471,48 +1483,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/ClientErrorResponse'
           description: ''
-  /clients/{client_id}/contacts/:
-    get:
-      operationId: clients_contacts_retrieve
-      description: Retrieve all contacts for a specific client.
-      summary: Get client contacts
-      parameters:
-        - in: path
-          name: client_id
-          schema:
-            type: string
-            format: uuid
-          description: UUID of the client
-          required: true
-      tags:
-        - Clients
-      security:
-        - cookieAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ClientContactResponse'
-          description: ''
-        '400':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ClientErrorResponse'
-          description: ''
-        '404':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ClientErrorResponse'
-          description: ''
-        '500':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ClientErrorResponse'
-          description: ''
   /clients/{client_id}/jobs/:
     get:
       operationId: clients_jobs_retrieve
@@ -1680,35 +1650,62 @@ paths:
                 $ref: '#/components/schemas/ClientErrorResponse'
           description: ''
   /clients/contacts/:
+    get:
+      operationId: clients_contacts_list
+      description: |-
+        ViewSet for ClientContact CRUD operations.
+
+        Endpoints:
+        - GET    /api/clients/contacts/           - list all contacts
+        - POST   /api/clients/contacts/           - create contact
+        - GET    /api/clients/contacts/<id>/      - retrieve contact
+        - PUT    /api/clients/contacts/<id>/      - full update
+        - PATCH  /api/clients/contacts/<id>/      - partial update
+        - DELETE /api/clients/contacts/<id>/      - soft delete (sets is_active=False)
+
+        Query Parameters:
+        - client_id: Filter contacts by client UUID
+      tags:
+        - clients
+      security:
+        - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ClientContact'
+          description: ''
     post:
       operationId: clients_contacts_create
       description: |-
-        Create a new client contact.
+        ViewSet for ClientContact CRUD operations.
 
-        Expected JSON:
-        {
-            "client_id": "uuid-of-client",
-            "name": "Contact Name",
-            "email": "contact@example.com",
-            "phone": "123-456-7890",
-            "position": "Job Title",
-            "is_primary": false,
-            "notes": "Additional notes"
-        }
-      summary: Create a new client contact
+        Endpoints:
+        - GET    /api/clients/contacts/           - list all contacts
+        - POST   /api/clients/contacts/           - create contact
+        - GET    /api/clients/contacts/<id>/      - retrieve contact
+        - PUT    /api/clients/contacts/<id>/      - full update
+        - PATCH  /api/clients/contacts/<id>/      - partial update
+        - DELETE /api/clients/contacts/<id>/      - soft delete (sets is_active=False)
+
+        Query Parameters:
+        - client_id: Filter contacts by client UUID
       tags:
         - clients
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ClientContactCreateRequest'
+              $ref: '#/components/schemas/ClientContact'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/ClientContactCreateRequest'
+              $ref: '#/components/schemas/ClientContact'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/ClientContactCreateRequest'
+              $ref: '#/components/schemas/ClientContact'
         required: true
       security:
         - cookieAuth: []
@@ -1717,20 +1714,164 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClientContactCreateResponse'
+                $ref: '#/components/schemas/ClientContact'
           description: ''
-        '400':
+  /clients/contacts/{id}/:
+    get:
+      operationId: clients_contacts_retrieve
+      description: |-
+        ViewSet for ClientContact CRUD operations.
+
+        Endpoints:
+        - GET    /api/clients/contacts/           - list all contacts
+        - POST   /api/clients/contacts/           - create contact
+        - GET    /api/clients/contacts/<id>/      - retrieve contact
+        - PUT    /api/clients/contacts/<id>/      - full update
+        - PATCH  /api/clients/contacts/<id>/      - partial update
+        - DELETE /api/clients/contacts/<id>/      - soft delete (sets is_active=False)
+
+        Query Parameters:
+        - client_id: Filter contacts by client UUID
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+            format: uuid
+          description: A UUID string identifying this Client Contact.
+          required: true
+      tags:
+        - clients
+      security:
+        - cookieAuth: []
+      responses:
+        '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClientErrorResponse'
+                $ref: '#/components/schemas/ClientContact'
           description: ''
-        '500':
+    put:
+      operationId: clients_contacts_update
+      description: |-
+        ViewSet for ClientContact CRUD operations.
+
+        Endpoints:
+        - GET    /api/clients/contacts/           - list all contacts
+        - POST   /api/clients/contacts/           - create contact
+        - GET    /api/clients/contacts/<id>/      - retrieve contact
+        - PUT    /api/clients/contacts/<id>/      - full update
+        - PATCH  /api/clients/contacts/<id>/      - partial update
+        - DELETE /api/clients/contacts/<id>/      - soft delete (sets is_active=False)
+
+        Query Parameters:
+        - client_id: Filter contacts by client UUID
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+            format: uuid
+          description: A UUID string identifying this Client Contact.
+          required: true
+      tags:
+        - clients
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ClientContact'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ClientContact'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ClientContact'
+        required: true
+      security:
+        - cookieAuth: []
+      responses:
+        '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClientErrorResponse'
+                $ref: '#/components/schemas/ClientContact'
           description: ''
+    patch:
+      operationId: clients_contacts_partial_update
+      description: |-
+        ViewSet for ClientContact CRUD operations.
+
+        Endpoints:
+        - GET    /api/clients/contacts/           - list all contacts
+        - POST   /api/clients/contacts/           - create contact
+        - GET    /api/clients/contacts/<id>/      - retrieve contact
+        - PUT    /api/clients/contacts/<id>/      - full update
+        - PATCH  /api/clients/contacts/<id>/      - partial update
+        - DELETE /api/clients/contacts/<id>/      - soft delete (sets is_active=False)
+
+        Query Parameters:
+        - client_id: Filter contacts by client UUID
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+            format: uuid
+          description: A UUID string identifying this Client Contact.
+          required: true
+      tags:
+        - clients
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedClientContact'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedClientContact'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedClientContact'
+      security:
+        - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClientContact'
+          description: ''
+    delete:
+      operationId: clients_contacts_destroy
+      description: |-
+        ViewSet for ClientContact CRUD operations.
+
+        Endpoints:
+        - GET    /api/clients/contacts/           - list all contacts
+        - POST   /api/clients/contacts/           - create contact
+        - GET    /api/clients/contacts/<id>/      - retrieve contact
+        - PUT    /api/clients/contacts/<id>/      - full update
+        - PATCH  /api/clients/contacts/<id>/      - partial update
+        - DELETE /api/clients/contacts/<id>/      - soft delete (sets is_active=False)
+
+        Query Parameters:
+        - client_id: Filter contacts by client UUID
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+            format: uuid
+          description: A UUID string identifying this Client Contact.
+          required: true
+      tags:
+        - clients
+      security:
+        - cookieAuth: []
+      responses:
+        '204':
+          description: No response body
   /clients/create/:
     post:
       operationId: clients_create_create
@@ -2532,6 +2673,31 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CostLineErrorResponse'
+          description: ''
+  /job/rest/data-integrity/scan/:
+    get:
+      operationId: scan_data_integrity
+      description: Check all foreign key relationships, JSON references, and business
+        rules for violations.
+      summary: Scan database integrity
+      tags:
+        - Data Quality
+      security:
+        - cookieAuth: []
+        - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DataIntegrityResponse'
+          description: ''
+        '500':
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
           description: ''
   /job/rest/data-quality/archived-jobs-compliance/:
     get:
@@ -4817,6 +4983,162 @@ paths:
               schema:
                 $ref: '#/components/schemas/JobsListResponse'
           description: ''
+  /timesheets/api/payroll/pay-runs/:
+    get:
+      operationId: timesheets_api_payroll_pay_runs_retrieve
+      description: Return pay run data for the requested week if it exists.
+      summary: Get pay run for a week
+      parameters:
+        - in: query
+          name: week_start_date
+          schema:
+            type: string
+            format: date
+          description: Monday of the week (YYYY-MM-DD)
+          required: true
+      tags:
+        - timesheets
+      security:
+        - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PayRunForWeekResponse'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClientErrorResponse'
+          description: ''
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClientErrorResponse'
+          description: ''
+  /timesheets/api/payroll/pay-runs/create:
+    post:
+      operationId: timesheets_api_payroll_pay_runs_create_create
+      description: Create a new pay run for the specified week.
+      summary: Create pay run for a week
+      tags:
+        - timesheets
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreatePayRunRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/CreatePayRunRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/CreatePayRunRequest'
+        required: true
+      security:
+        - cookieAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreatePayRunResponse'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClientErrorResponse'
+          description: ''
+        '409':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClientErrorResponse'
+          description: ''
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClientErrorResponse'
+          description: ''
+  /timesheets/api/payroll/pay-runs/refresh:
+    post:
+      operationId: timesheets_api_payroll_pay_runs_refresh_create
+      description: Synchronize local pay run cache with Xero.
+      summary: Refresh cached pay runs from Xero
+      tags:
+        - timesheets
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PayRunSyncResponse'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PayRunSyncResponse'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PayRunSyncResponse'
+        required: true
+      security:
+        - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PayRunSyncResponse'
+          description: ''
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClientErrorResponse'
+          description: ''
+  /timesheets/api/payroll/post-staff-week/:
+    post:
+      operationId: timesheets_api_payroll_post_staff_week_create
+      description: Post a week's timesheet to Xero Payroll.
+      summary: Post weekly timesheet to Xero Payroll
+      tags:
+        - timesheets
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PostWeekToXeroRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PostWeekToXeroRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PostWeekToXeroRequest'
+        required: true
+      security:
+        - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PostWeekToXeroResponse'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClientErrorResponse'
+          description: ''
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClientErrorResponse'
+          description: ''
   /timesheets/api/staff/:
     get:
       operationId: timesheets_api_staff_retrieve
@@ -4876,8 +5198,8 @@ paths:
   /timesheets/api/weekly/:
     get:
       operationId: timesheets_api_weekly_retrieve
-      description: Return weekly timesheet data (5 or 7 days based on feature flag).
-      summary: Standard weekly overview (Mon–Sun when enabled, Mon–Fri when disabled)
+      description: Return weekly timesheet data with payroll fields (5/7 days).
+      summary: Weekly overview with payroll data (Mon–Sun/Mon–Fri)
       parameters:
         - in: query
           name: start_date
@@ -4949,42 +5271,6 @@ paths:
               schema:
                 type: object
                 additionalProperties: {}
-          description: ''
-        '400':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ClientErrorResponse'
-          description: ''
-        '500':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ClientErrorResponse'
-          description: ''
-  /timesheets/api/weekly/ims/:
-    get:
-      operationId: timesheets_api_weekly_ims_retrieve
-      description: Return IMS-formatted weekly timesheet data.
-      summary: IMS weekly overview (Tue–Fri + next Mon)
-      parameters:
-        - in: query
-          name: start_date
-          schema:
-            type: string
-            format: date
-          description: Monday of target week in YYYY-MM-DD format. Defaults to current
-            week.
-      tags:
-        - timesheets
-      security:
-        - cookieAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/IMSWeeklyTimesheetData'
           description: ''
         '400':
           content:
@@ -5534,80 +5820,162 @@ components:
     BlankEnum:
       enum:
         - ''
-    ClientContactCreateRequest:
+    BrokenFKReference:
       type: object
-      description: Serializer for client contact creation request
+      description: Details of a broken foreign key reference.
       properties:
-        client_id:
+        model:
+          type: string
+          description: Model name
+        record_id:
+          type: string
+          description: Record's UUID
+        field:
+          type: string
+          description: FK field name
+        target_model:
+          type: string
+          description: Target model that doesn't exist
+        target_id:
+          type: string
+          description: Target UUID that doesn't exist
+      required:
+        - field
+        - model
+        - record_id
+        - target_id
+        - target_model
+    BrokenJSONReference:
+      type: object
+      description: Details of a broken JSON field reference.
+      properties:
+        model:
+          type: string
+          description: Model name
+        record_id:
+          type: string
+          description: Record's UUID
+        field:
+          type: string
+          description: JSON field path (e.g., meta.staff_id)
+        staff_id:
+          type: string
+          nullable: true
+          description: Invalid staff UUID
+        stock_id:
+          type: string
+          nullable: true
+          description: Invalid stock UUID
+        purchase_order_line_id:
+          type: string
+          nullable: true
+          description: Invalid PO line UUID
+        issue:
+          type: string
+          nullable: true
+          description: Issue description
+      required:
+        - field
+        - model
+        - record_id
+    BusinessRuleViolation:
+      type: object
+      description: Details of a business rule violation.
+      properties:
+        model:
+          type: string
+          description: Model name
+        record_id:
+          type: string
+          description: Record's UUID
+        field:
+          type: string
+          description: Field name
+        rule:
+          type: string
+          description: Business rule that was violated
+        expected:
+          type: string
+          nullable: true
+          description: Expected value
+        actual:
+          type: string
+          nullable: true
+          description: Actual value
+        path:
+          type: array
+          items:
+            type: string
+          nullable: true
+          description: Path for circular references
+        expected_path:
+          type: string
+          nullable: true
+          description: Expected file path
+      required:
+        - field
+        - model
+        - record_id
+        - rule
+    ClientContact:
+      type: object
+      description: Serializer for ClientContact model.
+      properties:
+        id:
           type: string
           format: uuid
+          readOnly: true
+        client:
+          type: string
+          format: uuid
+          description: The client this contact belongs to
         name:
           type: string
+          description: Full name of the contact person
           maxLength: 255
         email:
           type: string
           format: email
+          nullable: true
+          description: Email address of the contact
+          maxLength: 254
         phone:
           type: string
-          maxLength: 50
+          nullable: true
+          description: Phone number of the contact
+          maxLength: 150
         position:
           type: string
+          nullable: true
+          description: Job title if it's helpful - else leave blank
           maxLength: 255
         is_primary:
           type: boolean
-          default: false
+          description: Indicates if this is the primary contact for the client
         notes:
           type: string
-      required:
-        - client_id
-        - name
-    ClientContactCreateResponse:
-      type: object
-      description: Serializer for client contact creation response
-      properties:
-        success:
+          nullable: true
+          description: Additional notes about this contact
+        is_active:
           type: boolean
-        contact:
-          $ref: '#/components/schemas/ClientContactResult'
-        message:
+          readOnly: true
+          description: Soft delete flag - inactive contacts are hidden from normal
+            queries
+        created_at:
           type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
       required:
-        - contact
-        - message
-        - success
-    ClientContactResponse:
-      type: object
-      description: Serializer for client contacts response
-      properties:
-        results:
-          type: array
-          items:
-            $ref: '#/components/schemas/ClientContactResult'
-      required:
-        - results
-    ClientContactResult:
-      type: object
-      description: Serializer for individual client contact result
-      properties:
-        id:
-          type: string
-        name:
-          type: string
-        email:
-          type: string
-        phone:
-          type: string
-        position:
-          type: string
-        is_primary:
-          type: boolean
-      required:
-        - email
+        - client
+        - created_at
         - id
-        - is_primary
+        - is_active
         - name
-        - phone
-        - position
+        - updated_at
     ClientCreateRequest:
       type: object
       description: Serializer for client creation request
@@ -5976,6 +6344,41 @@ components:
           nullable: true
           description: The Xero tenant ID to use for this company
           maxLength: 100
+        xero_annual_leave_type_id:
+          type: string
+          nullable: true
+          description: Xero Payroll Leave Type ID for Annual Leave
+          maxLength: 100
+        xero_sick_leave_type_id:
+          type: string
+          nullable: true
+          description: Xero Payroll Leave Type ID for Sick Leave
+          maxLength: 100
+        xero_other_leave_type_id:
+          type: string
+          nullable: true
+          description: Xero Payroll Leave Type ID for Other Leave
+          maxLength: 100
+        xero_unpaid_leave_type_id:
+          type: string
+          nullable: true
+          description: Xero Payroll Leave Type ID for Unpaid Leave
+          maxLength: 100
+        xero_ordinary_earnings_rate_id:
+          type: string
+          nullable: true
+          description: Xero Payroll earnings rate ID for Ordinary Time (1.0x)
+          maxLength: 100
+        xero_time_half_earnings_rate_id:
+          type: string
+          nullable: true
+          description: Xero Payroll earnings rate ID for Time and a Half (1.5x)
+          maxLength: 100
+        xero_double_time_earnings_rate_id:
+          type: string
+          nullable: true
+          description: Xero Payroll earnings rate ID for Double Time (2.0x)
+          maxLength: 100
         mon_start:
           type: string
           format: time
@@ -6030,6 +6433,12 @@ components:
           nullable: true
           description: Name of the internal shop client for tracking shop work (e.g.,
             'MSM (Shop)')
+          maxLength: 255
+        test_client_name:
+          type: string
+          nullable: true
+          description: Name of the test client used for testing (e.g., 'ABC Carpet
+            Cleaning TEST IGNORE'). This client's name is preserved during data backports.
           maxLength: 255
         billable_threshold_green:
           type: number
@@ -6347,6 +6756,39 @@ components:
         - hours
         - profitMargin
         - rev
+    CreatePayRunRequest:
+      type: object
+      description: Request serializer for creating a pay run
+      properties:
+        week_start_date:
+          type: string
+          format: date
+          description: Monday of the week (YYYY-MM-DD)
+      required:
+        - week_start_date
+    CreatePayRunResponse:
+      type: object
+      description: Response serializer for created pay run
+      properties:
+        pay_run_id:
+          type: string
+        status:
+          type: string
+        period_start_date:
+          type: string
+          format: date
+        period_end_date:
+          type: string
+          format: date
+        payment_date:
+          type: string
+          format: date
+      required:
+        - pay_run_id
+        - payment_date
+        - period_end_date
+        - period_start_date
+        - status
     CustomTokenObtainPair:
       type: object
       description: Custom serializer that accepts username and maps it to email
@@ -6432,6 +6874,60 @@ components:
         - total_non_billable_hours
         - total_revenue
         - total_scheduled_hours
+    DataIntegrityResponse:
+      type: object
+      description: Response for data integrity scan.
+      properties:
+        scanned_at:
+          type: string
+          format: date-time
+          description: When the scan was performed
+        broken_fk_references:
+          type: array
+          items:
+            $ref: '#/components/schemas/BrokenFKReference'
+          description: List of broken foreign key references
+        broken_json_references:
+          type: array
+          items:
+            $ref: '#/components/schemas/BrokenJSONReference'
+          description: List of broken JSON field references
+        business_rule_violations:
+          type: array
+          items:
+            $ref: '#/components/schemas/BusinessRuleViolation'
+          description: List of business rule violations
+        summary:
+          allOf:
+            - $ref: '#/components/schemas/DataIntegritySummary'
+          description: Summary statistics
+      required:
+        - broken_fk_references
+        - broken_json_references
+        - business_rule_violations
+        - scanned_at
+        - summary
+    DataIntegritySummary:
+      type: object
+      description: Summary of data integrity scan results.
+      properties:
+        total_broken_fks:
+          type: integer
+          description: Number of broken foreign key references found
+        total_broken_json_refs:
+          type: integer
+          description: Number of broken JSON references found
+        total_business_rule_violations:
+          type: integer
+          description: Number of business rule violations found
+        total_issues:
+          type: integer
+          description: Total issues found
+      required:
+        - total_broken_fks
+        - total_broken_json_refs
+        - total_business_rule_violations
+        - total_issues
     DeliveryReceiptAllocation:
       type: object
       description: Serializer for individual allocation within a delivery receipt
@@ -6728,221 +7224,6 @@ components:
             type: string
         error:
           type: string
-    IMSWeeklyStaffData:
-      type: object
-      description: Serializer for staff data in IMS weekly timesheet context
-      properties:
-        staff_id:
-          type: string
-          format: uuid
-        name:
-          type: string
-        weekly_hours:
-          type: array
-          items:
-            $ref: '#/components/schemas/IMSWeeklyStaffDataWeeklyHours'
-        total_hours:
-          type: number
-          format: double
-          maximum: 100000000
-          minimum: -100000000
-          exclusiveMaximum: true
-          exclusiveMinimum: true
-        total_billable_hours:
-          type: number
-          format: double
-          maximum: 100000000
-          minimum: -100000000
-          exclusiveMaximum: true
-          exclusiveMinimum: true
-        billable_percentage:
-          type: number
-          format: double
-          maximum: 1000
-          minimum: -1000
-          exclusiveMaximum: true
-          exclusiveMinimum: true
-        status:
-          type: string
-        total_standard_hours:
-          type: number
-          format: double
-          maximum: 100000000
-          minimum: -100000000
-          exclusiveMaximum: true
-          exclusiveMinimum: true
-        total_time_and_half_hours:
-          type: number
-          format: double
-          maximum: 100000000
-          minimum: -100000000
-          exclusiveMaximum: true
-          exclusiveMinimum: true
-        total_double_time_hours:
-          type: number
-          format: double
-          maximum: 100000000
-          minimum: -100000000
-          exclusiveMaximum: true
-          exclusiveMinimum: true
-        total_overtime:
-          type: number
-          format: double
-          maximum: 100000000
-          minimum: -100000000
-          exclusiveMaximum: true
-          exclusiveMinimum: true
-      required:
-        - billable_percentage
-        - name
-        - staff_id
-        - status
-        - total_billable_hours
-        - total_double_time_hours
-        - total_hours
-        - total_overtime
-        - total_standard_hours
-        - total_time_and_half_hours
-        - weekly_hours
-    IMSWeeklyStaffDataWeeklyHours:
-      type: object
-      description: Serializer for weekly hours data of staff in IMS context
-      properties:
-        day:
-          type: string
-        hours:
-          type: number
-          format: double
-          maximum: 1000
-          minimum: -1000
-          exclusiveMaximum: true
-          exclusiveMinimum: true
-        billable_hours:
-          type: number
-          format: double
-          maximum: 1000
-          minimum: -1000
-          exclusiveMaximum: true
-          exclusiveMinimum: true
-        scheduled_hours:
-          type: number
-          format: double
-          maximum: 1000
-          minimum: -1000
-          exclusiveMaximum: true
-          exclusiveMinimum: true
-        status:
-          type: string
-        leave_type:
-          type: string
-          nullable: true
-        has_leave:
-          type: boolean
-          default: false
-        standard_hours:
-          type: number
-          format: double
-          maximum: 100000000
-          minimum: -100000000
-          exclusiveMaximum: true
-          exclusiveMinimum: true
-        time_and_half_hours:
-          type: number
-          format: double
-          maximum: 100000000
-          minimum: -100000000
-          exclusiveMaximum: true
-          exclusiveMinimum: true
-        double_time_hours:
-          type: number
-          format: double
-          maximum: 100000000
-          minimum: -100000000
-          exclusiveMaximum: true
-          exclusiveMinimum: true
-        unpaid_hours:
-          type: number
-          format: double
-          maximum: 100000000
-          minimum: -100000000
-          exclusiveMaximum: true
-          exclusiveMinimum: true
-        overtime:
-          type: number
-          format: double
-          maximum: 100000000
-          minimum: -100000000
-          exclusiveMaximum: true
-          exclusiveMinimum: true
-        leave_hours:
-          type: number
-          format: double
-          maximum: 100000000
-          minimum: -100000000
-          exclusiveMaximum: true
-          exclusiveMinimum: true
-      required:
-        - billable_hours
-        - day
-        - double_time_hours
-        - hours
-        - leave_hours
-        - overtime
-        - scheduled_hours
-        - standard_hours
-        - status
-        - time_and_half_hours
-        - unpaid_hours
-    IMSWeeklyTimesheetData:
-      type: object
-      description: |-
-        Same structure of WeeklyTimesheetDataSerializer but for IMS context
-        (substitutes staff_data for the IMS-specific serializer above)
-      properties:
-        start_date:
-          type: string
-          format: date
-        end_date:
-          type: string
-          format: date
-        week_days:
-          type: array
-          items:
-            type: string
-            format: date
-        staff_data:
-          type: array
-          items:
-            $ref: '#/components/schemas/IMSWeeklyStaffData'
-        weekly_summary:
-          $ref: '#/components/schemas/WeeklySummary'
-        job_metrics:
-          $ref: '#/components/schemas/JobMetrics'
-        summary_stats:
-          type: object
-          additionalProperties: {}
-        export_mode:
-          type: string
-        is_current_week:
-          type: boolean
-        navigation:
-          type: object
-          additionalProperties: {}
-        weekend_enabled:
-          type: boolean
-          default: false
-        week_type:
-          type: string
-      required:
-        - end_date
-        - export_mode
-        - is_current_week
-        - job_metrics
-        - staff_data
-        - start_date
-        - summary_stats
-        - week_days
-        - weekly_summary
     Invoice:
       type: object
       properties:
@@ -8888,12 +9169,17 @@ components:
           type: boolean
           description: Check if job has an actual cost set
           readOnly: true
+        leave_type:
+          type: string
+          description: Get leave type if this is a payroll job
+          readOnly: true
       required:
         - charge_out_rate
         - client_name
         - has_actual_costset
         - id
         - job_number
+        - leave_type
         - name
     ModernTimesheetJobGetResponse:
       type: object
@@ -9184,6 +9470,58 @@ components:
           writeOnly: true
           description: API Key for the provider. Leave blank to keep unchanged on
             update.
+    PatchedClientContact:
+      type: object
+      description: Serializer for ClientContact model.
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        client:
+          type: string
+          format: uuid
+          description: The client this contact belongs to
+        name:
+          type: string
+          description: Full name of the contact person
+          maxLength: 255
+        email:
+          type: string
+          format: email
+          nullable: true
+          description: Email address of the contact
+          maxLength: 254
+        phone:
+          type: string
+          nullable: true
+          description: Phone number of the contact
+          maxLength: 150
+        position:
+          type: string
+          nullable: true
+          description: Job title if it's helpful - else leave blank
+          maxLength: 255
+        is_primary:
+          type: boolean
+          description: Indicates if this is the primary contact for the client
+        notes:
+          type: string
+          nullable: true
+          description: Additional notes about this contact
+        is_active:
+          type: boolean
+          readOnly: true
+          description: Soft delete flag - inactive contacts are hidden from normal
+            queries
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
     PatchedClientUpdateRequest:
       type: object
       description: Serializer for client update request
@@ -9279,6 +9617,41 @@ components:
           nullable: true
           description: The Xero tenant ID to use for this company
           maxLength: 100
+        xero_annual_leave_type_id:
+          type: string
+          nullable: true
+          description: Xero Payroll Leave Type ID for Annual Leave
+          maxLength: 100
+        xero_sick_leave_type_id:
+          type: string
+          nullable: true
+          description: Xero Payroll Leave Type ID for Sick Leave
+          maxLength: 100
+        xero_other_leave_type_id:
+          type: string
+          nullable: true
+          description: Xero Payroll Leave Type ID for Other Leave
+          maxLength: 100
+        xero_unpaid_leave_type_id:
+          type: string
+          nullable: true
+          description: Xero Payroll Leave Type ID for Unpaid Leave
+          maxLength: 100
+        xero_ordinary_earnings_rate_id:
+          type: string
+          nullable: true
+          description: Xero Payroll earnings rate ID for Ordinary Time (1.0x)
+          maxLength: 100
+        xero_time_half_earnings_rate_id:
+          type: string
+          nullable: true
+          description: Xero Payroll earnings rate ID for Time and a Half (1.5x)
+          maxLength: 100
+        xero_double_time_earnings_rate_id:
+          type: string
+          nullable: true
+          description: Xero Payroll earnings rate ID for Double Time (2.0x)
+          maxLength: 100
         mon_start:
           type: string
           format: time
@@ -9333,6 +9706,12 @@ components:
           nullable: true
           description: Name of the internal shop client for tracking shop work (e.g.,
             'MSM (Shop)')
+          maxLength: 255
+        test_client_name:
+          type: string
+          nullable: true
+          description: Name of the test client used for testing (e.g., 'ABC Carpet
+            Cleaning TEST IGNORE'). This client's name is preserved during data backports.
           maxLength: 255
         billable_threshold_green:
           type: number
@@ -9648,6 +10027,139 @@ components:
           type: string
           format: date-time
           readOnly: true
+    PayRunDetails:
+      type: object
+      description: Serializer representing details from a Xero pay run.
+      properties:
+        pay_run_id:
+          type: string
+        payroll_calendar_id:
+          type: string
+          nullable: true
+        period_start_date:
+          type: string
+          format: date
+        period_end_date:
+          type: string
+          format: date
+        payment_date:
+          type: string
+          format: date
+        pay_run_status:
+          type: string
+        pay_run_type:
+          type: string
+          nullable: true
+      required:
+        - pay_run_id
+        - pay_run_status
+        - pay_run_type
+        - payment_date
+        - payroll_calendar_id
+        - period_end_date
+        - period_start_date
+    PayRunForWeekResponse:
+      type: object
+      description: Response serializer when fetching pay run data for a week.
+      properties:
+        exists:
+          type: boolean
+        pay_run:
+          allOf:
+            - $ref: '#/components/schemas/PayRunDetails'
+          nullable: true
+        warning:
+          type: string
+          nullable: true
+      required:
+        - exists
+        - pay_run
+    PayRunSyncResponse:
+      type: object
+      description: Response payload after refreshing cached pay runs.
+      properties:
+        fetched:
+          type: integer
+        created:
+          type: integer
+        updated:
+          type: integer
+      required:
+        - created
+        - fetched
+        - updated
+    PostWeekToXeroRequest:
+      type: object
+      description: Request serializer for posting weekly timesheet to Xero
+      properties:
+        staff_id:
+          type: string
+          format: uuid
+          description: Staff member UUID
+        week_start_date:
+          type: string
+          format: date
+          description: Monday of the week (YYYY-MM-DD)
+      required:
+        - staff_id
+        - week_start_date
+    PostWeekToXeroResponse:
+      type: object
+      description: Response serializer for posted timesheet
+      properties:
+        success:
+          type: boolean
+        xero_timesheet_id:
+          type: string
+          nullable: true
+        xero_leave_ids:
+          type: array
+          items:
+            type: string
+          nullable: true
+        entries_posted:
+          type: integer
+        work_hours:
+          type: number
+          format: double
+          maximum: 100000000
+          minimum: -100000000
+          exclusiveMaximum: true
+          exclusiveMinimum: true
+        other_leave_hours:
+          type: number
+          format: double
+          maximum: 100000000
+          minimum: -100000000
+          exclusiveMaximum: true
+          exclusiveMinimum: true
+        annual_sick_hours:
+          type: number
+          format: double
+          maximum: 100000000
+          minimum: -100000000
+          exclusiveMaximum: true
+          exclusiveMinimum: true
+        unpaid_hours:
+          type: number
+          format: double
+          maximum: 100000000
+          minimum: -100000000
+          exclusiveMaximum: true
+          exclusiveMinimum: true
+        errors:
+          type: array
+          items:
+            type: string
+      required:
+        - annual_sick_hours
+        - entries_posted
+        - errors
+        - other_leave_hours
+        - success
+        - unpaid_hours
+        - work_hours
+        - xero_timesheet_id
     PreviewQuoteResponse:
       type: object
       description: Serializer for preview quote response.
@@ -11651,7 +12163,8 @@ components:
         - status
     WeeklyStaffData:
       type: object
-      description: Serializer for staff data in weekly timesheet context
+      description: Serializer for staff data in weekly timesheet context with payroll
+        fields
       properties:
         staff_id:
           type: string
@@ -11676,6 +12189,13 @@ components:
           minimum: -100000000
           exclusiveMaximum: true
           exclusiveMinimum: true
+        total_scheduled_hours:
+          type: number
+          format: double
+          maximum: 100000000
+          minimum: -100000000
+          exclusiveMaximum: true
+          exclusiveMinimum: true
         billable_percentage:
           type: number
           format: double
@@ -11685,21 +12205,77 @@ components:
           exclusiveMinimum: true
         status:
           type: string
+        total_billed_hours:
+          type: number
+          format: double
+          maximum: 100000000
+          minimum: -100000000
+          exclusiveMaximum: true
+          exclusiveMinimum: true
+        total_unbilled_hours:
+          type: number
+          format: double
+          maximum: 100000000
+          minimum: -100000000
+          exclusiveMaximum: true
+          exclusiveMinimum: true
+        total_overtime_1_5x_hours:
+          type: number
+          format: double
+          maximum: 100000000
+          minimum: -100000000
+          exclusiveMaximum: true
+          exclusiveMinimum: true
+        total_overtime_2x_hours:
+          type: number
+          format: double
+          maximum: 100000000
+          minimum: -100000000
+          exclusiveMaximum: true
+          exclusiveMinimum: true
+        total_sick_leave_hours:
+          type: number
+          format: double
+          maximum: 100000000
+          minimum: -100000000
+          exclusiveMaximum: true
+          exclusiveMinimum: true
+        total_annual_leave_hours:
+          type: number
+          format: double
+          maximum: 100000000
+          minimum: -100000000
+          exclusiveMaximum: true
+          exclusiveMinimum: true
+        total_other_leave_hours:
+          type: number
+          format: double
+          maximum: 100000000
+          minimum: -100000000
+          exclusiveMaximum: true
+          exclusiveMinimum: true
       required:
         - billable_percentage
         - name
         - staff_id
         - status
+        - total_annual_leave_hours
         - total_billable_hours
+        - total_billed_hours
         - total_hours
+        - total_other_leave_hours
+        - total_overtime_1_5x_hours
+        - total_overtime_2x_hours
+        - total_scheduled_hours
+        - total_sick_leave_hours
+        - total_unbilled_hours
         - weekly_hours
     WeeklyStaffDataWeeklyHours:
       type: object
-      description: Serializer for weekly hours data of staff
+      description: Serializer for weekly hours data of staff with payroll fields
       properties:
         day:
           type: string
-          format: date
         hours:
           type: number
           format: double
@@ -11728,13 +12304,69 @@ components:
           nullable: true
         has_leave:
           type: boolean
+          default: false
+        billed_hours:
+          type: number
+          format: double
+          maximum: 100000000
+          minimum: -100000000
+          exclusiveMaximum: true
+          exclusiveMinimum: true
+        unbilled_hours:
+          type: number
+          format: double
+          maximum: 100000000
+          minimum: -100000000
+          exclusiveMaximum: true
+          exclusiveMinimum: true
+        overtime_1_5x_hours:
+          type: number
+          format: double
+          maximum: 100000000
+          minimum: -100000000
+          exclusiveMaximum: true
+          exclusiveMinimum: true
+        overtime_2x_hours:
+          type: number
+          format: double
+          maximum: 100000000
+          minimum: -100000000
+          exclusiveMaximum: true
+          exclusiveMinimum: true
+        sick_leave_hours:
+          type: number
+          format: double
+          maximum: 100000000
+          minimum: -100000000
+          exclusiveMaximum: true
+          exclusiveMinimum: true
+        annual_leave_hours:
+          type: number
+          format: double
+          maximum: 100000000
+          minimum: -100000000
+          exclusiveMaximum: true
+          exclusiveMinimum: true
+        other_leave_hours:
+          type: number
+          format: double
+          maximum: 100000000
+          minimum: -100000000
+          exclusiveMaximum: true
+          exclusiveMinimum: true
       required:
+        - annual_leave_hours
         - billable_hours
+        - billed_hours
         - day
-        - has_leave
         - hours
+        - other_leave_hours
+        - overtime_1_5x_hours
+        - overtime_2x_hours
         - scheduled_hours
+        - sick_leave_hours
         - status
+        - unbilled_hours
     WeeklySummary:
       type: object
       description: Serializer for weekly summary data
@@ -11761,19 +12393,16 @@ components:
         - total_hours
     WeeklyTimesheetData:
       type: object
-      description: Serializer for comprehensive weekly timesheet data
+      description: Serializer for complete weekly timesheet data with payroll fields
       properties:
         start_date:
           type: string
-          format: date
         end_date:
           type: string
-          format: date
         week_days:
           type: array
           items:
             type: string
-            format: date
         staff_data:
           type: array
           items:
@@ -11783,8 +12412,7 @@ components:
         job_metrics:
           $ref: '#/components/schemas/JobMetrics'
         summary_stats:
-          type: object
-          additionalProperties: {}
+          $ref: '#/components/schemas/SummaryStats'
         export_mode:
           type: string
         is_current_week:
@@ -11792,9 +12420,9 @@ components:
         navigation:
           type: object
           additionalProperties: {}
+          nullable: true
         weekend_enabled:
           type: boolean
-          default: false
         week_type:
           type: string
       required:

--- a/src/api/generated/api.ts
+++ b/src/api/generated/api.ts
@@ -344,6 +344,13 @@ const CompanyDefaults = z
     gdrive_quotes_folder_url: z.string().max(200).url().nullish(),
     gdrive_quotes_folder_id: z.string().max(100).nullish(),
     xero_tenant_id: z.string().max(100).nullish(),
+    xero_annual_leave_type_id: z.string().max(100).nullish(),
+    xero_sick_leave_type_id: z.string().max(100).nullish(),
+    xero_other_leave_type_id: z.string().max(100).nullish(),
+    xero_unpaid_leave_type_id: z.string().max(100).nullish(),
+    xero_ordinary_earnings_rate_id: z.string().max(100).nullish(),
+    xero_time_half_earnings_rate_id: z.string().max(100).nullish(),
+    xero_double_time_earnings_rate_id: z.string().max(100).nullish(),
     mon_start: z.string().optional(),
     mon_end: z.string().optional(),
     tue_start: z.string().optional(),
@@ -359,6 +366,7 @@ const CompanyDefaults = z
     last_xero_sync: z.string().datetime({ offset: true }).nullish(),
     last_xero_deep_sync: z.string().datetime({ offset: true }).nullish(),
     shop_client_name: z.string().max(255).nullish(),
+    test_client_name: z.string().max(255).nullish(),
     billable_threshold_green: z.number().gt(-1000).lt(1000).optional(),
     billable_threshold_amber: z.number().gt(-1000).lt(1000).optional(),
     daily_gp_target: z.number().gt(-100000000).lt(100000000).optional(),
@@ -381,6 +389,13 @@ const PatchedCompanyDefaults = z
     gdrive_quotes_folder_url: z.string().max(200).url().nullable(),
     gdrive_quotes_folder_id: z.string().max(100).nullable(),
     xero_tenant_id: z.string().max(100).nullable(),
+    xero_annual_leave_type_id: z.string().max(100).nullable(),
+    xero_sick_leave_type_id: z.string().max(100).nullable(),
+    xero_other_leave_type_id: z.string().max(100).nullable(),
+    xero_unpaid_leave_type_id: z.string().max(100).nullable(),
+    xero_ordinary_earnings_rate_id: z.string().max(100).nullable(),
+    xero_time_half_earnings_rate_id: z.string().max(100).nullable(),
+    xero_double_time_earnings_rate_id: z.string().max(100).nullable(),
     mon_start: z.string(),
     mon_end: z.string(),
     tue_start: z.string(),
@@ -396,6 +411,7 @@ const PatchedCompanyDefaults = z
     last_xero_sync: z.string().datetime({ offset: true }).nullable(),
     last_xero_deep_sync: z.string().datetime({ offset: true }).nullable(),
     shop_client_name: z.string().max(255).nullable(),
+    test_client_name: z.string().max(255).nullable(),
     billable_threshold_green: z.number().gt(-1000).lt(1000),
     billable_threshold_amber: z.number().gt(-1000).lt(1000),
     daily_gp_target: z.number().gt(-100000000).lt(100000000),
@@ -512,17 +528,6 @@ const ClientErrorResponse = z
     details: z.string().optional(),
   })
   .passthrough()
-const ClientContactResult = z
-  .object({
-    id: z.string(),
-    name: z.string(),
-    email: z.string(),
-    phone: z.string(),
-    position: z.string(),
-    is_primary: z.boolean(),
-  })
-  .passthrough()
-const ClientContactResponse = z.object({ results: z.array(ClientContactResult) }).passthrough()
 const ClientJobHeader = z
   .object({
     job_id: z.string().uuid(),
@@ -568,23 +573,36 @@ const PatchedClientUpdateRequest = z
   .partial()
   .passthrough()
 const ClientNameOnly = z.object({ id: z.string().uuid(), name: z.string() }).passthrough()
-const ClientContactCreateRequest = z
+const ClientContact = z
   .object({
-    client_id: z.string().uuid(),
+    id: z.string().uuid(),
+    client: z.string().uuid(),
     name: z.string().max(255),
-    email: z.string().email().optional(),
-    phone: z.string().max(50).optional(),
-    position: z.string().max(255).optional(),
-    is_primary: z.boolean().optional().default(false),
-    notes: z.string().optional(),
+    email: z.string().max(254).email().nullish(),
+    phone: z.string().max(150).nullish(),
+    position: z.string().max(255).nullish(),
+    is_primary: z.boolean().optional(),
+    notes: z.string().nullish(),
+    is_active: z.boolean(),
+    created_at: z.string().datetime({ offset: true }),
+    updated_at: z.string().datetime({ offset: true }),
   })
   .passthrough()
-const ClientContactCreateResponse = z
+const PatchedClientContact = z
   .object({
-    success: z.boolean(),
-    contact: ClientContactResult,
-    message: z.string(),
+    id: z.string().uuid(),
+    client: z.string().uuid(),
+    name: z.string().max(255),
+    email: z.string().max(254).email().nullable(),
+    phone: z.string().max(150).nullable(),
+    position: z.string().max(255).nullable(),
+    is_primary: z.boolean(),
+    notes: z.string().nullable(),
+    is_active: z.boolean(),
+    created_at: z.string().datetime({ offset: true }),
+    updated_at: z.string().datetime({ offset: true }),
   })
+  .partial()
   .passthrough()
 const ClientCreateRequest = z
   .object({
@@ -857,6 +875,55 @@ const CostLineCreateUpdate = z
   })
   .passthrough()
 const CostLineErrorResponse = z.object({ error: z.string() }).passthrough()
+const BrokenFKReference = z
+  .object({
+    model: z.string(),
+    record_id: z.string(),
+    field: z.string(),
+    target_model: z.string(),
+    target_id: z.string(),
+  })
+  .passthrough()
+const BrokenJSONReference = z
+  .object({
+    model: z.string(),
+    record_id: z.string(),
+    field: z.string(),
+    staff_id: z.string().nullish(),
+    stock_id: z.string().nullish(),
+    purchase_order_line_id: z.string().nullish(),
+    issue: z.string().nullish(),
+  })
+  .passthrough()
+const BusinessRuleViolation = z
+  .object({
+    model: z.string(),
+    record_id: z.string(),
+    field: z.string(),
+    rule: z.string(),
+    expected: z.string().nullish(),
+    actual: z.string().nullish(),
+    path: z.array(z.string()).nullish(),
+    expected_path: z.string().nullish(),
+  })
+  .passthrough()
+const DataIntegritySummary = z
+  .object({
+    total_broken_fks: z.number().int(),
+    total_broken_json_refs: z.number().int(),
+    total_business_rule_violations: z.number().int(),
+    total_issues: z.number().int(),
+  })
+  .passthrough()
+const DataIntegrityResponse = z
+  .object({
+    scanned_at: z.string().datetime({ offset: true }),
+    broken_fk_references: z.array(BrokenFKReference),
+    broken_json_references: z.array(BrokenJSONReference),
+    business_rule_violations: z.array(BusinessRuleViolation),
+    summary: DataIntegritySummary,
+  })
+  .passthrough()
 const ArchivedJobIssue = z
   .object({
     job_id: z.string(),
@@ -2005,10 +2072,62 @@ const ModernTimesheetJob = z
     status: Status7b9Enum.optional(),
     charge_out_rate: z.number().gt(-100000000).lt(100000000),
     has_actual_costset: z.boolean(),
+    leave_type: z.string(),
   })
   .passthrough()
 const JobsListResponse = z
   .object({ jobs: z.array(ModernTimesheetJob), total_count: z.number().int() })
+  .passthrough()
+const PayRunDetails = z
+  .object({
+    pay_run_id: z.string(),
+    payroll_calendar_id: z.string().nullable(),
+    period_start_date: z.string(),
+    period_end_date: z.string(),
+    payment_date: z.string(),
+    pay_run_status: z.string(),
+    pay_run_type: z.string().nullable(),
+  })
+  .passthrough()
+const PayRunForWeekResponse = z
+  .object({
+    exists: z.boolean(),
+    pay_run: PayRunDetails.nullable(),
+    warning: z.string().nullish(),
+  })
+  .passthrough()
+const CreatePayRunRequest = z.object({ week_start_date: z.string() }).passthrough()
+const CreatePayRunResponse = z
+  .object({
+    pay_run_id: z.string(),
+    status: z.string(),
+    period_start_date: z.string(),
+    period_end_date: z.string(),
+    payment_date: z.string(),
+  })
+  .passthrough()
+const PayRunSyncResponse = z
+  .object({
+    fetched: z.number().int(),
+    created: z.number().int(),
+    updated: z.number().int(),
+  })
+  .passthrough()
+const PostWeekToXeroRequest = z
+  .object({ staff_id: z.string().uuid(), week_start_date: z.string() })
+  .passthrough()
+const PostWeekToXeroResponse = z
+  .object({
+    success: z.boolean(),
+    xero_timesheet_id: z.string().nullable(),
+    xero_leave_ids: z.array(z.string()).nullish(),
+    entries_posted: z.number().int(),
+    work_hours: z.number().gt(-100000000).lt(100000000),
+    other_leave_hours: z.number().gt(-100000000).lt(100000000),
+    annual_sick_hours: z.number().gt(-100000000).lt(100000000),
+    unpaid_hours: z.number().gt(-100000000).lt(100000000),
+    errors: z.array(z.string()),
+  })
   .passthrough()
 const ModernStaff = z
   .object({
@@ -2032,7 +2151,14 @@ const WeeklyStaffDataWeeklyHours = z
     scheduled_hours: z.number().gt(-1000).lt(1000),
     status: z.string(),
     leave_type: z.string().nullish(),
-    has_leave: z.boolean(),
+    has_leave: z.boolean().optional().default(false),
+    billed_hours: z.number().gt(-100000000).lt(100000000),
+    unbilled_hours: z.number().gt(-100000000).lt(100000000),
+    overtime_1_5x_hours: z.number().gt(-100000000).lt(100000000),
+    overtime_2x_hours: z.number().gt(-100000000).lt(100000000),
+    sick_leave_hours: z.number().gt(-100000000).lt(100000000),
+    annual_leave_hours: z.number().gt(-100000000).lt(100000000),
+    other_leave_hours: z.number().gt(-100000000).lt(100000000),
   })
   .passthrough()
 const WeeklyStaffData = z
@@ -2042,8 +2168,16 @@ const WeeklyStaffData = z
     weekly_hours: z.array(WeeklyStaffDataWeeklyHours),
     total_hours: z.number().gt(-100000000).lt(100000000),
     total_billable_hours: z.number().gt(-100000000).lt(100000000),
+    total_scheduled_hours: z.number().gt(-100000000).lt(100000000),
     billable_percentage: z.number().gt(-1000).lt(1000),
     status: z.string(),
+    total_billed_hours: z.number().gt(-100000000).lt(100000000),
+    total_unbilled_hours: z.number().gt(-100000000).lt(100000000),
+    total_overtime_1_5x_hours: z.number().gt(-100000000).lt(100000000),
+    total_overtime_2x_hours: z.number().gt(-100000000).lt(100000000),
+    total_sick_leave_hours: z.number().gt(-100000000).lt(100000000),
+    total_annual_leave_hours: z.number().gt(-100000000).lt(100000000),
+    total_other_leave_hours: z.number().gt(-100000000).lt(100000000),
   })
   .passthrough()
 const WeeklySummary = z
@@ -2068,59 +2202,11 @@ const WeeklyTimesheetData = z
     staff_data: z.array(WeeklyStaffData),
     weekly_summary: WeeklySummary,
     job_metrics: JobMetrics,
-    summary_stats: z.object({}).partial().passthrough(),
+    summary_stats: SummaryStats,
     export_mode: z.string(),
     is_current_week: z.boolean(),
-    navigation: z.object({}).partial().passthrough().optional(),
-    weekend_enabled: z.boolean().optional().default(false),
-    week_type: z.string().optional(),
-  })
-  .passthrough()
-const IMSWeeklyStaffDataWeeklyHours = z
-  .object({
-    day: z.string(),
-    hours: z.number().gt(-1000).lt(1000),
-    billable_hours: z.number().gt(-1000).lt(1000),
-    scheduled_hours: z.number().gt(-1000).lt(1000),
-    status: z.string(),
-    leave_type: z.string().nullish(),
-    has_leave: z.boolean().optional().default(false),
-    standard_hours: z.number().gt(-100000000).lt(100000000),
-    time_and_half_hours: z.number().gt(-100000000).lt(100000000),
-    double_time_hours: z.number().gt(-100000000).lt(100000000),
-    unpaid_hours: z.number().gt(-100000000).lt(100000000),
-    overtime: z.number().gt(-100000000).lt(100000000),
-    leave_hours: z.number().gt(-100000000).lt(100000000),
-  })
-  .passthrough()
-const IMSWeeklyStaffData = z
-  .object({
-    staff_id: z.string().uuid(),
-    name: z.string(),
-    weekly_hours: z.array(IMSWeeklyStaffDataWeeklyHours),
-    total_hours: z.number().gt(-100000000).lt(100000000),
-    total_billable_hours: z.number().gt(-100000000).lt(100000000),
-    billable_percentage: z.number().gt(-1000).lt(1000),
-    status: z.string(),
-    total_standard_hours: z.number().gt(-100000000).lt(100000000),
-    total_time_and_half_hours: z.number().gt(-100000000).lt(100000000),
-    total_double_time_hours: z.number().gt(-100000000).lt(100000000),
-    total_overtime: z.number().gt(-100000000).lt(100000000),
-  })
-  .passthrough()
-const IMSWeeklyTimesheetData = z
-  .object({
-    start_date: z.string(),
-    end_date: z.string(),
-    week_days: z.array(z.string()),
-    staff_data: z.array(IMSWeeklyStaffData),
-    weekly_summary: WeeklySummary,
-    job_metrics: JobMetrics,
-    summary_stats: z.object({}).partial().passthrough(),
-    export_mode: z.string(),
-    is_current_week: z.boolean(),
-    navigation: z.object({}).partial().passthrough().optional(),
-    weekend_enabled: z.boolean().optional().default(false),
+    navigation: z.object({}).partial().passthrough().nullish(),
+    weekend_enabled: z.boolean().optional(),
     week_type: z.string().optional(),
   })
   .passthrough()
@@ -2197,16 +2283,14 @@ export const schemas = {
   XeroQuoteCreateRequest,
   ClientDetailResponse,
   ClientErrorResponse,
-  ClientContactResult,
-  ClientContactResponse,
   ClientJobHeader,
   ClientJobsResponse,
   ClientUpdateRequest,
   ClientUpdateResponse,
   PatchedClientUpdateRequest,
   ClientNameOnly,
-  ClientContactCreateRequest,
-  ClientContactCreateResponse,
+  ClientContact,
+  PatchedClientContact,
   ClientCreateRequest,
   ClientSearchResult,
   ClientCreateResponse,
@@ -2246,6 +2330,11 @@ export const schemas = {
   PatchedCostLineCreateUpdate,
   CostLineCreateUpdate,
   CostLineErrorResponse,
+  BrokenFKReference,
+  BrokenJSONReference,
+  BusinessRuleViolation,
+  DataIntegritySummary,
+  DataIntegrityResponse,
   ArchivedJobIssue,
   ComplianceSummary,
   ArchivedJobsComplianceResponse,
@@ -2382,6 +2471,13 @@ export const schemas = {
   DailyTimesheetSummary,
   ModernTimesheetJob,
   JobsListResponse,
+  PayRunDetails,
+  PayRunForWeekResponse,
+  CreatePayRunRequest,
+  CreatePayRunResponse,
+  PayRunSyncResponse,
+  PostWeekToXeroRequest,
+  PostWeekToXeroResponse,
   ModernStaff,
   StaffListResponse,
   WeeklyStaffDataWeeklyHours,
@@ -2389,9 +2485,6 @@ export const schemas = {
   WeeklySummary,
   JobMetrics,
   WeeklyTimesheetData,
-  IMSWeeklyStaffDataWeeklyHours,
-  IMSWeeklyStaffData,
-  IMSWeeklyTimesheetData,
   XeroError,
   PaginatedXeroErrorList,
 }
@@ -2441,6 +2534,14 @@ Returns:
     JSON response with job aging data structure`,
     requestFormat: 'json',
     response: JobAgingResponse,
+  },
+  {
+    method: 'get',
+    path: '/accounting/api/reports/job-movement/',
+    alias: 'accounting_api_reports_job_movement_retrieve',
+    description: `Handle GET request for job movement metrics.`,
+    requestFormat: 'json',
+    response: z.void(),
   },
   {
     method: 'get',
@@ -3406,35 +3507,6 @@ Endpoint: /api/app-errors/&lt;id&gt;/`,
   },
   {
     method: 'get',
-    path: '/clients/:client_id/contacts/',
-    alias: 'clients_contacts_retrieve',
-    description: `Retrieve all contacts for a specific client.`,
-    requestFormat: 'json',
-    parameters: [
-      {
-        name: 'client_id',
-        type: 'Path',
-        schema: z.string().uuid(),
-      },
-    ],
-    response: ClientContactResponse,
-    errors: [
-      {
-        status: 400,
-        schema: ClientErrorResponse,
-      },
-      {
-        status: 404,
-        schema: ClientErrorResponse,
-      },
-      {
-        status: 500,
-        schema: ClientErrorResponse,
-      },
-    ],
-  },
-  {
-    method: 'get',
     path: '/clients/:client_id/jobs/',
     alias: 'clients_jobs_retrieve',
     description: `Retrieve all jobs for a specific client.`,
@@ -3541,40 +3613,163 @@ Endpoint: /api/app-errors/&lt;id&gt;/`,
     ],
   },
   {
+    method: 'get',
+    path: '/clients/contacts/',
+    alias: 'clients_contacts_list',
+    description: `ViewSet for ClientContact CRUD operations.
+
+Endpoints:
+- GET    /api/clients/contacts/           - list all contacts
+- POST   /api/clients/contacts/           - create contact
+- GET    /api/clients/contacts/&lt;id&gt;/      - retrieve contact
+- PUT    /api/clients/contacts/&lt;id&gt;/      - full update
+- PATCH  /api/clients/contacts/&lt;id&gt;/      - partial update
+- DELETE /api/clients/contacts/&lt;id&gt;/      - soft delete (sets is_active&#x3D;False)
+
+Query Parameters:
+- client_id: Filter contacts by client UUID`,
+    requestFormat: 'json',
+    response: z.array(ClientContact),
+  },
+  {
     method: 'post',
     path: '/clients/contacts/',
     alias: 'clients_contacts_create',
-    description: `Create a new client contact.
+    description: `ViewSet for ClientContact CRUD operations.
 
-Expected JSON:
-{
-    &quot;client_id&quot;: &quot;uuid-of-client&quot;,
-    &quot;name&quot;: &quot;Contact Name&quot;,
-    &quot;email&quot;: &quot;contact@example.com&quot;,
-    &quot;phone&quot;: &quot;123-456-7890&quot;,
-    &quot;position&quot;: &quot;Job Title&quot;,
-    &quot;is_primary&quot;: false,
-    &quot;notes&quot;: &quot;Additional notes&quot;
-}`,
+Endpoints:
+- GET    /api/clients/contacts/           - list all contacts
+- POST   /api/clients/contacts/           - create contact
+- GET    /api/clients/contacts/&lt;id&gt;/      - retrieve contact
+- PUT    /api/clients/contacts/&lt;id&gt;/      - full update
+- PATCH  /api/clients/contacts/&lt;id&gt;/      - partial update
+- DELETE /api/clients/contacts/&lt;id&gt;/      - soft delete (sets is_active&#x3D;False)
+
+Query Parameters:
+- client_id: Filter contacts by client UUID`,
     requestFormat: 'json',
     parameters: [
       {
         name: 'body',
         type: 'Body',
-        schema: ClientContactCreateRequest,
+        schema: ClientContact,
       },
     ],
-    response: ClientContactCreateResponse,
-    errors: [
+    response: ClientContact,
+  },
+  {
+    method: 'get',
+    path: '/clients/contacts/:id/',
+    alias: 'clients_contacts_retrieve',
+    description: `ViewSet for ClientContact CRUD operations.
+
+Endpoints:
+- GET    /api/clients/contacts/           - list all contacts
+- POST   /api/clients/contacts/           - create contact
+- GET    /api/clients/contacts/&lt;id&gt;/      - retrieve contact
+- PUT    /api/clients/contacts/&lt;id&gt;/      - full update
+- PATCH  /api/clients/contacts/&lt;id&gt;/      - partial update
+- DELETE /api/clients/contacts/&lt;id&gt;/      - soft delete (sets is_active&#x3D;False)
+
+Query Parameters:
+- client_id: Filter contacts by client UUID`,
+    requestFormat: 'json',
+    parameters: [
       {
-        status: 400,
-        schema: ClientErrorResponse,
-      },
-      {
-        status: 500,
-        schema: ClientErrorResponse,
+        name: 'id',
+        type: 'Path',
+        schema: z.string().uuid(),
       },
     ],
+    response: ClientContact,
+  },
+  {
+    method: 'put',
+    path: '/clients/contacts/:id/',
+    alias: 'clients_contacts_update',
+    description: `ViewSet for ClientContact CRUD operations.
+
+Endpoints:
+- GET    /api/clients/contacts/           - list all contacts
+- POST   /api/clients/contacts/           - create contact
+- GET    /api/clients/contacts/&lt;id&gt;/      - retrieve contact
+- PUT    /api/clients/contacts/&lt;id&gt;/      - full update
+- PATCH  /api/clients/contacts/&lt;id&gt;/      - partial update
+- DELETE /api/clients/contacts/&lt;id&gt;/      - soft delete (sets is_active&#x3D;False)
+
+Query Parameters:
+- client_id: Filter contacts by client UUID`,
+    requestFormat: 'json',
+    parameters: [
+      {
+        name: 'body',
+        type: 'Body',
+        schema: ClientContact,
+      },
+      {
+        name: 'id',
+        type: 'Path',
+        schema: z.string().uuid(),
+      },
+    ],
+    response: ClientContact,
+  },
+  {
+    method: 'patch',
+    path: '/clients/contacts/:id/',
+    alias: 'clients_contacts_partial_update',
+    description: `ViewSet for ClientContact CRUD operations.
+
+Endpoints:
+- GET    /api/clients/contacts/           - list all contacts
+- POST   /api/clients/contacts/           - create contact
+- GET    /api/clients/contacts/&lt;id&gt;/      - retrieve contact
+- PUT    /api/clients/contacts/&lt;id&gt;/      - full update
+- PATCH  /api/clients/contacts/&lt;id&gt;/      - partial update
+- DELETE /api/clients/contacts/&lt;id&gt;/      - soft delete (sets is_active&#x3D;False)
+
+Query Parameters:
+- client_id: Filter contacts by client UUID`,
+    requestFormat: 'json',
+    parameters: [
+      {
+        name: 'body',
+        type: 'Body',
+        schema: PatchedClientContact,
+      },
+      {
+        name: 'id',
+        type: 'Path',
+        schema: z.string().uuid(),
+      },
+    ],
+    response: ClientContact,
+  },
+  {
+    method: 'delete',
+    path: '/clients/contacts/:id/',
+    alias: 'clients_contacts_destroy',
+    description: `ViewSet for ClientContact CRUD operations.
+
+Endpoints:
+- GET    /api/clients/contacts/           - list all contacts
+- POST   /api/clients/contacts/           - create contact
+- GET    /api/clients/contacts/&lt;id&gt;/      - retrieve contact
+- PUT    /api/clients/contacts/&lt;id&gt;/      - full update
+- PATCH  /api/clients/contacts/&lt;id&gt;/      - partial update
+- DELETE /api/clients/contacts/&lt;id&gt;/      - soft delete (sets is_active&#x3D;False)
+
+Query Parameters:
+- client_id: Filter contacts by client UUID`,
+    requestFormat: 'json',
+    parameters: [
+      {
+        name: 'id',
+        type: 'Path',
+        schema: z.string().uuid(),
+      },
+    ],
+    response: z.void(),
   },
   {
     method: 'post',
@@ -4126,6 +4321,20 @@ Dynamically infers the stock adjustment based on quantity change`,
       {
         status: 500,
         schema: z.object({ error: z.string() }).passthrough(),
+      },
+    ],
+  },
+  {
+    method: 'get',
+    path: '/job/rest/data-integrity/scan/',
+    alias: 'scan_data_integrity',
+    description: `Check all foreign key relationships, JSON references, and business rules for violations.`,
+    requestFormat: 'json',
+    response: DataIntegrityResponse,
+    errors: [
+      {
+        status: 500,
+        schema: z.object({}).partial().passthrough(),
       },
     ],
   },
@@ -5591,6 +5800,106 @@ Returns:
   },
   {
     method: 'get',
+    path: '/timesheets/api/payroll/pay-runs/',
+    alias: 'timesheets_api_payroll_pay_runs_retrieve',
+    description: `Return pay run data for the requested week if it exists.`,
+    requestFormat: 'json',
+    parameters: [
+      {
+        name: 'week_start_date',
+        type: 'Query',
+        schema: z.string(),
+      },
+    ],
+    response: PayRunForWeekResponse,
+    errors: [
+      {
+        status: 400,
+        schema: ClientErrorResponse,
+      },
+      {
+        status: 500,
+        schema: ClientErrorResponse,
+      },
+    ],
+  },
+  {
+    method: 'post',
+    path: '/timesheets/api/payroll/pay-runs/create',
+    alias: 'timesheets_api_payroll_pay_runs_create_create',
+    description: `Create a new pay run for the specified week.`,
+    requestFormat: 'json',
+    parameters: [
+      {
+        name: 'body',
+        type: 'Body',
+        schema: z.object({ week_start_date: z.string() }).passthrough(),
+      },
+    ],
+    response: CreatePayRunResponse,
+    errors: [
+      {
+        status: 400,
+        schema: ClientErrorResponse,
+      },
+      {
+        status: 409,
+        schema: ClientErrorResponse,
+      },
+      {
+        status: 500,
+        schema: ClientErrorResponse,
+      },
+    ],
+  },
+  {
+    method: 'post',
+    path: '/timesheets/api/payroll/pay-runs/refresh',
+    alias: 'timesheets_api_payroll_pay_runs_refresh_create',
+    description: `Synchronize local pay run cache with Xero.`,
+    requestFormat: 'json',
+    parameters: [
+      {
+        name: 'body',
+        type: 'Body',
+        schema: PayRunSyncResponse,
+      },
+    ],
+    response: PayRunSyncResponse,
+    errors: [
+      {
+        status: 500,
+        schema: ClientErrorResponse,
+      },
+    ],
+  },
+  {
+    method: 'post',
+    path: '/timesheets/api/payroll/post-staff-week/',
+    alias: 'timesheets_api_payroll_post_staff_week_create',
+    description: `Post a week&#x27;s timesheet to Xero Payroll.`,
+    requestFormat: 'json',
+    parameters: [
+      {
+        name: 'body',
+        type: 'Body',
+        schema: PostWeekToXeroRequest,
+      },
+    ],
+    response: PostWeekToXeroResponse,
+    errors: [
+      {
+        status: 400,
+        schema: ClientErrorResponse,
+      },
+      {
+        status: 500,
+        schema: ClientErrorResponse,
+      },
+    ],
+  },
+  {
+    method: 'get',
     path: '/timesheets/api/staff/',
     alias: 'timesheets_api_staff_retrieve',
     description: `Get filtered list of staff members for a specific date.`,
@@ -5635,7 +5944,7 @@ Returns:
     method: 'get',
     path: '/timesheets/api/weekly/',
     alias: 'timesheets_api_weekly_retrieve',
-    description: `Return weekly timesheet data (5 or 7 days based on feature flag).`,
+    description: `Return weekly timesheet data with payroll fields (5/7 days).`,
     requestFormat: 'json',
     parameters: [
       {
@@ -5680,31 +5989,6 @@ Expected payload:
       },
     ],
     response: z.object({}).partial().passthrough(),
-    errors: [
-      {
-        status: 400,
-        schema: ClientErrorResponse,
-      },
-      {
-        status: 500,
-        schema: ClientErrorResponse,
-      },
-    ],
-  },
-  {
-    method: 'get',
-    path: '/timesheets/api/weekly/ims/',
-    alias: 'timesheets_api_weekly_ims_retrieve',
-    description: `Return IMS-formatted weekly timesheet data.`,
-    requestFormat: 'json',
-    parameters: [
-      {
-        name: 'start_date',
-        type: 'Query',
-        schema: z.string().optional(),
-      },
-    ],
-    response: IMSWeeklyTimesheetData,
     errors: [
       {
         status: 400,

--- a/src/components/job/JobActualTab.vue
+++ b/src/components/job/JobActualTab.vue
@@ -271,6 +271,7 @@
 
 <script setup lang="ts">
 import { debugLog } from '../../utils/debug'
+import { formatCurrency } from '@/utils/string-formatting'
 
 import { onMounted, ref, computed, reactive } from 'vue'
 import { useRouter } from 'vue-router'
@@ -405,14 +406,6 @@ const invoiceButtonText = computed(() => {
     return 'Report a bug'
   }
 })
-
-// --- FORMATTING FUNCTIONS ---
-const formatCurrency = (amount: number | undefined | null): string => {
-  if (amount === null || amount === undefined) {
-    return new Intl.NumberFormat('en-NZ', { style: 'currency', currency: 'NZD' }).format(0)
-  }
-  return new Intl.NumberFormat('en-NZ', { style: 'currency', currency: 'NZD' }).format(amount)
-}
 
 const formatDate = (dateString: string | null | undefined) => {
   if (!dateString) return 'N/A'

--- a/src/components/job/JobCostAnalysisTab.vue
+++ b/src/components/job/JobCostAnalysisTab.vue
@@ -156,6 +156,7 @@
 import { computed, ref, onMounted } from 'vue'
 import { ArrowUp, ArrowDown, CheckCircle, AlertTriangle, XCircle } from 'lucide-vue-next'
 import { api } from '../../api/client'
+import { formatCurrency } from '@/utils/string-formatting'
 import { schemas } from '../../api/generated/api'
 import { z } from 'zod'
 
@@ -319,13 +320,6 @@ const quoteAccuracyDisplayValue = computed(() => {
   return percentDiff(actual.value.cost, quote.value.cost)
 })
 
-function formatCurrency(value: number): string {
-  return new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency: 'USD',
-    minimumFractionDigits: 2,
-  }).format(value)
-}
 function formatPercent(value: number): string {
   return `${value > 0 ? '+' : ''}${value.toFixed(1)}%`
 }

--- a/src/components/job/JobPricingGrids.vue
+++ b/src/components/job/JobPricingGrids.vue
@@ -22,7 +22,7 @@
           <div class="pt-2 border-t">
             <div class="flex justify-between font-semibold">
               <span>Total:</span>
-              <span>${{ formatCurrency(estimates.total) }}</span>
+              <span>{{ formatCurrency(estimates.total) }}</span>
             </div>
           </div>
         </div>
@@ -49,7 +49,7 @@
           <div class="pt-2 border-t">
             <div class="flex justify-between font-semibold">
               <span>Total:</span>
-              <span>${{ formatCurrency(quotes.total) }}</span>
+              <span>{{ formatCurrency(quotes.total) }}</span>
             </div>
           </div>
         </div>
@@ -76,7 +76,7 @@
           <div class="pt-2 border-t">
             <div class="flex justify-between font-semibold">
               <span>Total:</span>
-              <span>${{ formatCurrency(reality.total) }}</span>
+              <span>{{ formatCurrency(reality.total) }}</span>
             </div>
           </div>
         </div>
@@ -87,6 +87,7 @@
 
 <script setup lang="ts">
 import { debugLog } from '@/utils/debug'
+import { formatCurrency } from '@/utils/string-formatting'
 
 import { ref, watch } from 'vue'
 import SimpleTotalTable from './SimpleTotalTable.vue'
@@ -166,13 +167,6 @@ const emitDataChanged = () => {
     quotes: quotes.value,
     reality: reality.value,
   })
-}
-
-const formatCurrency = (amount: number | undefined | null): string => {
-  if (amount === null || amount === undefined || isNaN(amount)) {
-    return '0.00'
-  }
-  return amount.toFixed(2)
 }
 
 watch(

--- a/src/components/job/JobQuoteTab.vue
+++ b/src/components/job/JobQuoteTab.vue
@@ -567,6 +567,7 @@ import SmartCostLinesTable from '../shared/SmartCostLinesTable.vue'
 import CostSetSummaryCard from '../shared/CostSetSummaryCard.vue'
 import { quoteService } from '../../services/quote.service'
 import { toast } from 'vue-sonner'
+import { formatCurrency } from '@/utils/string-formatting'
 import { schemas } from '../../api/generated/api'
 import { api } from '../../api/client'
 import { z } from 'zod'
@@ -942,14 +943,6 @@ const deleteQuoteOnXero = async () => {
   } finally {
     isDeletingQuote.value = false
   }
-}
-
-// Helper functions for formatting
-function formatCurrency(value: number): string {
-  return new Intl.NumberFormat('en-NZ', {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  }).format(value)
 }
 
 function formatNumber(value: number): string {

--- a/src/components/job/StockConsumptionModal.vue
+++ b/src/components/job/StockConsumptionModal.vue
@@ -35,7 +35,7 @@
                 >
                   <div class="font-medium text-sm">{{ item.description }}</div>
                   <div class="text-xs text-gray-500">
-                    Stock: {{ item.quantity }} | Unit Cost: ${{ formatCurrency(item.unit_cost) }}
+                    Stock: {{ item.quantity }} | Unit Cost: {{ formatCurrency(item.unit_cost) }}
                   </div>
                 </div>
               </div>
@@ -162,6 +162,7 @@ import { schemas } from '../../api/generated/api'
 import { api } from '../../api/client'
 import { useCompanyDefaultsStore } from '../../stores/companyDefaults'
 import { debugLog } from '../../utils/debug'
+import { formatCurrency } from '@/utils/string-formatting'
 import { z } from 'zod'
 
 type StockItem = z.infer<typeof schemas.StockList>
@@ -206,10 +207,6 @@ const canSubmit = computed(() => {
 
 const totalRevenue = computed(() => formData.value.unit_rev * formData.value.quantity)
 const totalCost = computed(() => formData.value.unit_cost * formData.value.quantity)
-
-function formatCurrency(value: number): string {
-  return value.toFixed(2)
-}
 
 async function loadStockItems() {
   isLoading.value = true

--- a/src/components/kpi/KPICalendarDay.vue
+++ b/src/components/kpi/KPICalendarDay.vue
@@ -35,6 +35,7 @@
 import { computed } from 'vue'
 import { schemas } from '@/api/generated/api'
 import { z } from 'zod'
+import { formatCurrency } from '@/utils/string-formatting'
 
 type DayKPI = z.infer<typeof schemas.KPIDayData>
 type Thresholds = z.infer<typeof schemas.KPIThresholds>
@@ -73,15 +74,6 @@ function formatHours(hours: number): string {
   const minutes = Math.round((hours - wholeHours) * 60)
   if (minutes === 0) return `${wholeHours}h`
   return `${wholeHours}.${minutes < 10 ? '0' : ''}${Math.round(minutes / 6)}`
-}
-
-function formatCurrency(value: number): string {
-  return new Intl.NumberFormat('en-NZ', {
-    style: 'currency',
-    currency: 'NZD',
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
-  }).format(value)
 }
 </script>
 

--- a/src/components/kpi/KPIDayDetailsModal.vue
+++ b/src/components/kpi/KPIDayDetailsModal.vue
@@ -159,7 +159,7 @@ import {
 } from '@/components/ui/dialog'
 import { schemas } from '@/api/generated/api'
 import type { z } from 'zod'
-import { kpiService } from '@/services/kpi.service'
+import { formatCurrency } from '@/utils/string-formatting'
 
 // Use generated API types
 type KPIDayData = z.infer<typeof schemas.KPIDayData>
@@ -214,13 +214,6 @@ const adjustmentProfit = computed(() => {
   if (!props.dayData) return 0
   return adjustmentRevenue.value - adjustmentCost.value
 })
-
-function formatCurrency(value: number): string {
-  if (typeof value !== 'number' || isNaN(value)) {
-    return '$0.00'
-  }
-  return kpiService.formatCurrency(value)
-}
 
 function formatDateTitle(dateString: string | undefined): string {
   if (!dateString) return ''

--- a/src/components/kpi/KPILabourDetailsModal.vue
+++ b/src/components/kpi/KPILabourDetailsModal.vue
@@ -177,6 +177,7 @@ import {
 import { schemas } from '@/api/generated/api'
 import { z } from 'zod'
 import { kpiService } from '@/services/kpi.service'
+import { formatCurrency } from '@/utils/string-formatting'
 
 type MonthlyTotals = z.infer<typeof schemas.KPIMonthlyTotals>
 type DayKPI = z.infer<typeof schemas.KPIDayData>
@@ -267,10 +268,6 @@ const labourProfitPercent = computed(() => {
 
 function formatHours(hours: number): string {
   return kpiService.formatHours(hours)
-}
-
-function formatCurrency(value: number): string {
-  return kpiService.formatCurrency(value)
 }
 
 function formatDateShort(dateString: string): string {

--- a/src/components/kpi/KPIMaterialsDetailsModal.vue
+++ b/src/components/kpi/KPIMaterialsDetailsModal.vue
@@ -213,6 +213,7 @@ import {
 import { schemas } from '@/api/generated/api'
 import { z } from 'zod'
 import { kpiService } from '@/services/kpi.service'
+import { formatCurrency } from '@/utils/string-formatting'
 
 type DayKPI = z.infer<typeof schemas.KPIDayData>
 
@@ -347,10 +348,6 @@ function getDayTotalNonLabour(day: DayKPI): number {
   const materialRev = day.details?.material_revenue || 0
   const adjustmentRev = getDayAdjustmentRevenue(day)
   return materialRev + adjustmentRev
-}
-
-function formatCurrency(value: number): string {
-  return kpiService.formatCurrency(value)
 }
 
 function formatDateShort(dateString: string): string {

--- a/src/components/kpi/KPIProfitDetailsModal.vue
+++ b/src/components/kpi/KPIProfitDetailsModal.vue
@@ -151,6 +151,7 @@ import {
 import { schemas } from '@/api/generated/api'
 import { z } from 'zod'
 import { kpiService } from '@/services/kpi.service'
+import { formatCurrency } from '@/utils/string-formatting'
 
 type MonthlyTotals = z.infer<typeof schemas.KPIMonthlyTotals>
 type Thresholds = z.infer<typeof schemas.KPIThresholds>
@@ -269,8 +270,4 @@ const targetPerformanceClass = computed(() => {
   if (perf >= 80) return 'text-yellow-600'
   return 'text-red-600'
 })
-
-function formatCurrency(value: number): string {
-  return kpiService.formatCurrency(value)
-}
 </script>

--- a/src/components/quote/QuoteCostLinesGrid.vue
+++ b/src/components/quote/QuoteCostLinesGrid.vue
@@ -116,16 +116,16 @@
                 <span v-if="line.kind === 'time'" class="text-xs text-gray-500 ml-1">hrs</span>
               </td>
               <td class="px-4 py-3 text-sm text-gray-900 text-right">
-                ${{ formatCurrency(line.unit_cost) }}
+                {{ formatCurrency(line.unit_cost) }}
               </td>
               <td class="px-4 py-3 text-sm text-gray-900 text-right">
-                ${{ formatCurrency(line.unit_rev) }}
+                {{ formatCurrency(line.unit_rev) }}
               </td>
               <td class="px-4 py-3 text-sm text-gray-900 text-right font-medium">
-                ${{ formatCurrency(line.quantity * line.unit_cost) }}
+                {{ formatCurrency(line.quantity * line.unit_cost) }}
               </td>
               <td class="px-4 py-3 text-sm text-gray-900 text-right font-medium">
-                ${{ formatCurrency(line.quantity * line.unit_rev) }}
+                {{ formatCurrency(line.quantity * line.unit_rev) }}
               </td>
               <td class="px-4 py-3 text-xs text-gray-500 text-center">
                 <span
@@ -149,6 +149,7 @@
 <script setup lang="ts">
 import { schemas } from '../../api/generated/api'
 import { z } from 'zod'
+import { formatCurrency } from '@/utils/string-formatting'
 
 // Extend CostLine type to include timestamp fields (to be added to backend schema)
 type CostLine = z.infer<typeof schemas.CostLine> & {
@@ -169,13 +170,6 @@ withDefaults(
 function formatNumber(value: number): string {
   return new Intl.NumberFormat('en-US', {
     minimumFractionDigits: 0,
-    maximumFractionDigits: 2,
-  }).format(value)
-}
-
-function formatCurrency(value: number): string {
-  return new Intl.NumberFormat('en-US', {
-    minimumFractionDigits: 2,
     maximumFractionDigits: 2,
   }).format(value)
 }

--- a/src/components/quote/QuoteSummaryCard.vue
+++ b/src/components/quote/QuoteSummaryCard.vue
@@ -60,21 +60,21 @@
             <div class="flex flex-col">
               <span class="text-xs text-gray-500">Material Cost</span>
               <span class="text-lg font-semibold text-red-600">
-                ${{ formatCurrency(breakdown.material.cost) }}
+                {{ formatCurrency(breakdown.material.cost) }}
               </span>
             </div>
 
             <div class="flex flex-col">
               <span class="text-xs text-gray-500">Time Cost</span>
               <span class="text-lg font-semibold text-red-600">
-                ${{ formatCurrency(breakdown.labour.cost) }}
+                {{ formatCurrency(breakdown.labour.cost) }}
               </span>
             </div>
 
             <div class="flex flex-col pt-2 border-t border-gray-200">
               <span class="text-xs text-gray-500">Total Cost</span>
               <span class="text-xl font-bold text-red-600">
-                ${{ formatCurrency(quoteData.summary.cost) }}
+                {{ formatCurrency(quoteData.summary.cost) }}
               </span>
             </div>
           </div>
@@ -87,21 +87,21 @@
             <div class="flex flex-col">
               <span class="text-xs text-gray-500">Material Revenue</span>
               <span class="text-lg font-semibold text-green-600">
-                ${{ formatCurrency(breakdown.material.revenue) }}
+                {{ formatCurrency(breakdown.material.revenue) }}
               </span>
             </div>
 
             <div class="flex flex-col">
               <span class="text-xs text-gray-500">Time Revenue</span>
               <span class="text-lg font-semibold text-green-600">
-                ${{ formatCurrency(breakdown.labour.revenue) }}
+                {{ formatCurrency(breakdown.labour.revenue) }}
               </span>
             </div>
 
             <div class="flex flex-col pt-2 border-t border-gray-200">
               <span class="text-xs text-gray-500">Total Revenue</span>
               <span class="text-xl font-bold text-green-600">
-                ${{ formatCurrency(quoteData.summary.rev) }}
+                {{ formatCurrency(quoteData.summary.rev) }}
               </span>
             </div>
           </div>
@@ -204,10 +204,9 @@
                     <div>
                       <div class="font-medium">{{ item.desc }}</div>
                       <div class="text-sm text-gray-600">
-                        {{ item.kind }} • Qty: {{ item.quantity }} • Cost: ${{
-                          formatCurrency(item.unit_cost)
-                        }}
-                        • Total: ${{ formatCurrency(item.total_cost) }}
+                        {{ item.kind }} • Qty: {{ item.quantity }} • Cost:
+                        {{ formatCurrency(item.unit_cost) }} • Total:
+                        {{ formatCurrency(item.total_cost) }}
                       </div>
                     </div>
                     <span class="text-green-600 font-bold text-xs px-2 py-1 bg-green-100 rounded"
@@ -237,10 +236,9 @@
                     <div>
                       <div class="font-medium">{{ item.desc }}</div>
                       <div class="text-sm text-gray-600">
-                        {{ item.kind }} • Qty: {{ item.quantity }} • Cost: ${{
-                          formatCurrency(item.unit_cost)
-                        }}
-                        • Total: ${{ formatCurrency(item.total_cost) }}
+                        {{ item.kind }} • Qty: {{ item.quantity }} • Cost:
+                        {{ formatCurrency(item.unit_cost) }} • Total:
+                        {{ formatCurrency(item.total_cost) }}
                       </div>
                     </div>
                     <span class="text-blue-600 font-bold text-xs px-2 py-1 bg-blue-100 rounded"
@@ -348,6 +346,7 @@ import type { QuoteSheet } from '@/schemas/job.schemas'
 import { extractQuoteErrorMessage, logError } from '@/utils/error-handler'
 import { schemas } from '@/api/generated/api'
 import { z } from 'zod'
+import { formatCurrency } from '@/utils/string-formatting'
 
 type Job = z.infer<typeof schemas.Job>
 type QuoteData = z.infer<typeof schemas.CostSet> // kind == 'quote'
@@ -576,13 +575,6 @@ async function confirmRefresh() {
 function formatNumber(value: number): string {
   return new Intl.NumberFormat('en-US', {
     minimumFractionDigits: 0,
-    maximumFractionDigits: 2,
-  }).format(value)
-}
-
-function formatCurrency(value: number): string {
-  return new Intl.NumberFormat('en-US', {
-    minimumFractionDigits: 2,
     maximumFractionDigits: 2,
   }).format(value)
 }

--- a/src/components/shared/CompactSummaryCard.vue
+++ b/src/components/shared/CompactSummaryCard.vue
@@ -35,22 +35,20 @@
       <!-- Total Cost -->
       <div class="flex justify-between items-center">
         <span class="text-xs text-gray-500">Total Cost</span>
-        <span class="text-lg font-bold text-red-600">${{ formatCurrency(typedSummary.cost) }}</span>
+        <span class="text-lg font-bold text-red-600">{{ formatCurrency(typedSummary.cost) }}</span>
       </div>
 
       <!-- Total Revenue -->
       <div class="flex justify-between items-center">
         <span class="text-xs text-gray-500">Total Revenue</span>
-        <span class="text-lg font-bold text-green-600"
-          >${{ formatCurrency(typedSummary.rev) }}</span
-        >
+        <span class="text-lg font-bold text-green-600">{{ formatCurrency(typedSummary.rev) }}</span>
       </div>
 
       <!-- Profit -->
       <div class="flex justify-between items-center pt-2 border-t border-gray-200">
         <span class="text-xs text-gray-500">Profit</span>
         <span :class="['text-lg font-bold', profit >= 0 ? 'text-green-600' : 'text-red-600']">
-          ${{ formatCurrency(profit) }}
+          {{ formatCurrency(profit) }}
         </span>
       </div>
 
@@ -75,6 +73,7 @@ import { computed } from 'vue'
 import { FileX, Maximize2 } from 'lucide-vue-next'
 import { Button } from '../ui/button'
 import { schemas } from '../../api/generated/api'
+import { formatCurrency } from '@/utils/string-formatting'
 import { z } from 'zod'
 
 type CostLine = z.infer<typeof schemas.CostLine>
@@ -124,13 +123,6 @@ const profit = computed(() => {
 function formatNumber(value: number): string {
   return new Intl.NumberFormat('en-US', {
     minimumFractionDigits: 0,
-    maximumFractionDigits: 2,
-  }).format(value)
-}
-
-function formatCurrency(value: number): string {
-  return new Intl.NumberFormat('en-US', {
-    minimumFractionDigits: 2,
     maximumFractionDigits: 2,
   }).format(value)
 }

--- a/src/components/shared/CostLinesGrid.vue
+++ b/src/components/shared/CostLinesGrid.vue
@@ -127,16 +127,16 @@
                 }}<span v-if="line.kind === 'time'" class="text-xs text-gray-500 ml-1">hrs</span>
               </td>
               <td class="px-4 py-3 text-sm text-gray-900 text-right">
-                ${{ formatCurrency(line.unit_cost) }}
+                {{ formatCurrency(line.unit_cost) }}
               </td>
               <td class="px-4 py-3 text-sm text-gray-900 text-right">
-                ${{ formatCurrency(line.unit_rev) }}
+                {{ formatCurrency(line.unit_rev) }}
               </td>
               <td class="px-4 py-3 text-sm text-gray-900 text-right font-medium">
-                ${{ formatCurrency(calculateTotal(line.quantity, line.unit_cost)) }}
+                {{ formatCurrency(calculateTotal(line.quantity, line.unit_cost)) }}
               </td>
               <td class="px-4 py-3 text-sm text-gray-900 text-right font-medium">
-                ${{ formatCurrency(calculateTotal(line.quantity, line.unit_rev)) }}
+                {{ formatCurrency(calculateTotal(line.quantity, line.unit_rev)) }}
               </td>
               <td class="px-4 py-3 text-xs text-gray-500 text-center">
                 <span
@@ -202,6 +202,7 @@
 <script setup lang="ts">
 import { schemas } from '../../api/generated/api'
 import { z } from 'zod'
+import { formatCurrency } from '@/utils/string-formatting'
 
 // Extend CostLine type to include timestamp fields (to be added to backend schema)
 type CostLine = z.infer<typeof schemas.CostLine> & {
@@ -235,14 +236,6 @@ function formatNumber(value: number | undefined): string {
   const num = value || 0
   return new Intl.NumberFormat('en-NZ', {
     minimumFractionDigits: 0,
-    maximumFractionDigits: 2,
-  }).format(num)
-}
-
-function formatCurrency(value: number | undefined): string {
-  const num = value || 0
-  return new Intl.NumberFormat('en-NZ', {
-    minimumFractionDigits: 2,
     maximumFractionDigits: 2,
   }).format(num)
 }

--- a/src/components/shared/CostSetSummaryCard.vue
+++ b/src/components/shared/CostSetSummaryCard.vue
@@ -33,27 +33,27 @@
           <div class="space-y-2">
             <div class="flex flex-col">
               <span class="text-xs text-gray-500">Material Cost</span>
-              <span class="text-lg font-semibold text-red-600"
-                >${{ formatCurrency(breakdown.material.cost) }}</span
-              >
+              <span class="text-lg font-semibold text-red-600">{{
+                formatCurrency(breakdown.material.cost)
+              }}</span>
             </div>
             <div class="flex flex-col">
               <span class="text-xs text-gray-500">Time Cost</span>
-              <span class="text-lg font-semibold text-red-600"
-                >${{ formatCurrency(breakdown.labour.cost) }}</span
-              >
+              <span class="text-lg font-semibold text-red-600">{{
+                formatCurrency(breakdown.labour.cost)
+              }}</span>
             </div>
             <div v-if="breakdown.other.cost > 0" class="flex flex-col">
               <span class="text-xs text-gray-500">Other Cost</span>
-              <span class="text-lg font-semibold text-red-600"
-                >${{ formatCurrency(breakdown.other.cost) }}</span
-              >
+              <span class="text-lg font-semibold text-red-600">{{
+                formatCurrency(breakdown.other.cost)
+              }}</span>
             </div>
             <div class="flex flex-col pt-2 border-t border-gray-200">
               <span class="text-xs text-gray-500">Total Cost</span>
-              <span class="text-xl font-bold text-red-600"
-                >${{ formatCurrency(typedSummary.cost) }}</span
-              >
+              <span class="text-xl font-bold text-red-600">{{
+                formatCurrency(typedSummary.cost)
+              }}</span>
             </div>
           </div>
         </div>
@@ -62,27 +62,27 @@
           <div class="space-y-2">
             <div class="flex flex-col">
               <span class="text-xs text-gray-500">Material Revenue</span>
-              <span class="text-lg font-semibold text-green-600"
-                >${{ formatCurrency(breakdown.material.revenue) }}</span
-              >
+              <span class="text-lg font-semibold text-green-600">{{
+                formatCurrency(breakdown.material.revenue)
+              }}</span>
             </div>
             <div class="flex flex-col">
               <span class="text-xs text-gray-500">Time Revenue</span>
-              <span class="text-lg font-semibold text-green-600"
-                >${{ formatCurrency(breakdown.labour.revenue) }}</span
-              >
+              <span class="text-lg font-semibold text-green-600">{{
+                formatCurrency(breakdown.labour.revenue)
+              }}</span>
             </div>
             <div v-if="breakdown.other.revenue > 0" class="flex flex-col">
               <span class="text-xs text-gray-500">Other Revenue</span>
-              <span class="text-lg font-semibold text-green-600"
-                >${{ formatCurrency(breakdown.other.revenue) }}</span
-              >
+              <span class="text-lg font-semibold text-green-600">{{
+                formatCurrency(breakdown.other.revenue)
+              }}</span>
             </div>
             <div class="flex flex-col pt-2 border-t border-gray-200">
               <span class="text-xs text-gray-500">Total Revenue</span>
-              <span class="text-xl font-bold text-green-600"
-                >${{ formatCurrency(typedSummary.rev) }}</span
-              >
+              <span class="text-xl font-bold text-green-600">{{
+                formatCurrency(typedSummary.rev)
+              }}</span>
             </div>
           </div>
         </div>
@@ -122,6 +122,7 @@
 import { computed } from 'vue'
 import { FileX } from 'lucide-vue-next'
 import { schemas } from '../../api/generated/api'
+import { formatCurrency } from '@/utils/string-formatting'
 import { z } from 'zod'
 
 type CostLine = z.infer<typeof schemas.CostLine>
@@ -250,13 +251,6 @@ const breakdown = computed(() => {
 function formatNumber(value: number): string {
   return new Intl.NumberFormat('en-US', {
     minimumFractionDigits: 0,
-    maximumFractionDigits: 2,
-  }).format(value)
-}
-
-function formatCurrency(value: number): string {
-  return new Intl.NumberFormat('en-US', {
-    minimumFractionDigits: 2,
     maximumFractionDigits: 2,
   }).format(value)
 }

--- a/src/components/timesheet/WeeklyMetricsModal.vue
+++ b/src/components/timesheet/WeeklyMetricsModal.vue
@@ -265,6 +265,7 @@ import DialogTitle from '../ui/dialog/DialogTitle.vue'
 import { schemas } from '../../api/generated/api'
 import { api } from '../../api/client'
 import { z } from 'zod'
+import { formatCurrency } from '../../utils/string-formatting'
 
 type WeeklyJobs = z.infer<typeof schemas.WeeklyMetrics>
 type WeeklyTimesheetData = z.infer<typeof schemas.WeeklyTimesheetData>
@@ -388,13 +389,6 @@ const toggleDetailedMode = () => {
   if (detailedMode.value && jobs.value.length === 0) {
     loadJobs()
   }
-}
-
-const formatCurrency = (amount: number): string => {
-  return new Intl.NumberFormat('en-US', {
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
-  }).format(amount)
 }
 
 const loadJobs = async () => {

--- a/src/composables/useClientLookup.ts
+++ b/src/composables/useClientLookup.ts
@@ -64,10 +64,10 @@ export function useClientLookup() {
 
   const loadClientContacts = async (clientId: string) => {
     try {
-      const response = await api.clients_contacts_retrieve({
-        params: { client_id: clientId },
+      const response = await api.clients_contacts_list({
+        queries: { client_id: clientId },
       })
-      contacts.value = response.results
+      contacts.value = Array.isArray(response) ? response : []
     } catch (error) {
       console.error('Error loading client contacts:', error)
       contacts.value = []

--- a/src/composables/usePurchaseOrderGrid.ts
+++ b/src/composables/usePurchaseOrderGrid.ts
@@ -11,6 +11,7 @@ import { customTheme } from '@/plugins/ag-grid'
 import { schemas } from '@/api/generated/api'
 import { z } from 'zod'
 import { PurchaseOrderJobCellEditor } from '@/components/purchasing/PurchaseOrderJobCellEditor'
+import { formatCurrency } from '@/utils/string-formatting'
 
 type PurchaseOrderLineUI = z.infer<typeof schemas.PurchaseOrderLine>
 
@@ -63,7 +64,7 @@ export function usePurchaseOrderGrid(lines: Ref<PurchaseOrderLineUI[]>) {
       width: 120,
       editable: true,
       type: 'numericColumn',
-      valueFormatter: (params: ValueFormatterParams) => `$${(params.value || 0).toFixed(2)}`,
+      valueFormatter: (params: ValueFormatterParams) => formatCurrency(params.value || 0),
     },
     {
       headerName: 'Total',
@@ -74,7 +75,7 @@ export function usePurchaseOrderGrid(lines: Ref<PurchaseOrderLineUI[]>) {
         const data = params.data as PurchaseOrderLineUI
         return (data.quantity || 0) * (data.unit_price || 0)
       },
-      valueFormatter: (params: ValueFormatterParams) => `$${(params.value || 0).toFixed(2)}`,
+      valueFormatter: (params: ValueFormatterParams) => formatCurrency(params.value || 0),
       editable: false,
     },
     {

--- a/src/composables/useTimesheetEntryGrid.ts
+++ b/src/composables/useTimesheetEntryGrid.ts
@@ -18,6 +18,7 @@ import type {
 } from 'ag-grid-community'
 import { customTheme } from '@/plugins/ag-grid'
 import { TimesheetEntryJobCellEditor } from '@/components/timesheet/TimesheetEntryJobCellEditor'
+import { formatCurrency } from '@/utils/string-formatting'
 import { useTimesheetEntryCalculations } from '@/composables/useTimesheetEntryCalculations'
 import { TimesheetEntryJobSelectionItem } from '@/constants/timesheet'
 
@@ -155,7 +156,7 @@ export function useTimesheetEntryGrid(
       field: 'wage',
       width: 100,
       editable: false,
-      valueFormatter: (params: ValueFormatterParams) => `$${(params.value || 0).toFixed(2)}`,
+      valueFormatter: (params: ValueFormatterParams) => formatCurrency(params.value || 0),
       cellClass: 'text-right',
       cellStyle: { color: '#059669', fontWeight: '600' },
     },
@@ -164,7 +165,7 @@ export function useTimesheetEntryGrid(
       field: 'bill',
       width: 100,
       editable: false,
-      valueFormatter: (params: ValueFormatterParams) => `$${(params.value || 0).toFixed(2)}`,
+      valueFormatter: (params: ValueFormatterParams) => formatCurrency(params.value || 0),
       cellClass: 'text-right',
       cellStyle: { color: '#2563EB', fontWeight: '600' },
     },

--- a/src/plugins/ag-grid.ts
+++ b/src/plugins/ag-grid.ts
@@ -1,5 +1,6 @@
 import { ModuleRegistry, AllCommunityModule, themeQuartz } from 'ag-grid-community'
 import type { ValueFormatterParams } from 'ag-grid-community'
+import { formatCurrency } from '@/utils/string-formatting'
 
 ModuleRegistry.registerModules([AllCommunityModule])
 
@@ -58,10 +59,7 @@ export const defaultGridOptions = {
       cellClass: 'numeric-cell currency-cell',
       valueFormatter: (params: ValueFormatterParams) => {
         if (params.value == null) return ''
-        return new Intl.NumberFormat('en-NZ', {
-          style: 'currency',
-          currency: 'NZD',
-        }).format(params.value)
+        return formatCurrency(params.value)
       },
     },
     hoursColumn: {

--- a/src/services/daily-timesheet.service.ts
+++ b/src/services/daily-timesheet.service.ts
@@ -2,6 +2,7 @@ import { schemas } from '../api/generated/api'
 import { api } from '../api/client'
 import { today } from './date.service'
 import type { z } from 'zod'
+import { formatCurrency as formatCurrencyUtil } from '@/utils/string-formatting'
 
 // Use inferred types from Zod schemas
 type DailyTimesheetSummary = z.infer<typeof schemas.DailyTimesheetSummary>
@@ -43,7 +44,7 @@ export const formatHours = (hours: number): string => {
 }
 
 export const formatCurrency = (amount: number): string => {
-  return `$${amount.toFixed(2)}`
+  return formatCurrencyUtil(amount)
 }
 
 export const getStatusVariant = (statusClass: string): string => {

--- a/src/services/job-aging-report.service.ts
+++ b/src/services/job-aging-report.service.ts
@@ -1,5 +1,6 @@
 import api from '@/plugins/axios'
 import { debugLog } from '@/utils/debug'
+import { exportToCsv } from '@/utils/string-formatting'
 
 export interface JobAgingData {
   id: string
@@ -60,7 +61,7 @@ export class JobAgingReportService {
     }
   }
 
-  exportToCsv(jobs: JobAgingData[]): void {
+  exportToFile(jobs: JobAgingData[]): void {
     const headers = [
       'Job Number',
       'Job Name',
@@ -75,7 +76,7 @@ export class JobAgingReportService {
       'Actual Total',
     ]
 
-    const csvData = jobs.map((job) => [
+    const rows = jobs.map((job) => [
       job.job_number,
       job.name,
       job.client_name,
@@ -89,19 +90,7 @@ export class JobAgingReportService {
       job.financial_data.actual_total,
     ])
 
-    const csvContent = [headers, ...csvData]
-      .map((row) => row.map((cell) => `"${cell}"`).join(','))
-      .join('\n')
-
-    const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' })
-    const link = document.createElement('a')
-    const url = URL.createObjectURL(blob)
-    link.setAttribute('href', url)
-    link.setAttribute('download', `job-aging-report-${new Date().toISOString().split('T')[0]}.csv`)
-    link.style.visibility = 'hidden'
-    document.body.appendChild(link)
-    link.click()
-    document.body.removeChild(link)
+    exportToCsv(headers, rows, `job-aging-report-${new Date().toISOString().split('T')[0]}`)
   }
 
   getActivityAgeStatus(daysAgo: number): 'recent' | 'warning' | 'stale' {

--- a/src/services/kpi.service.ts
+++ b/src/services/kpi.service.ts
@@ -8,6 +8,7 @@ import type {
   KPIThresholds,
 } from '@/api/generated/api'
 import { debugLog } from '@/utils/debug'
+import { formatCurrency } from '@/utils/string-formatting'
 
 // Types for params - keeping as local since they're for input validation
 export interface KPICalendarParams {
@@ -78,10 +79,7 @@ class KPIService {
   }
 
   formatCurrency(value: number): string {
-    return new Intl.NumberFormat('en-NZ', {
-      style: 'currency',
-      currency: 'NZD',
-    }).format(value)
+    return formatCurrency(value)
   }
 
   formatHours(hours: number): string {

--- a/src/utils/string-formatting.ts
+++ b/src/utils/string-formatting.ts
@@ -93,3 +93,54 @@ export function formatCurrency(value: number | null | undefined): string {
     currency: 'NZD',
   }).format(value)
 }
+
+/**
+ * Escapes a cell value for CSV format
+ * Wraps in quotes and escapes internal quotes
+ */
+function escapeCsvCell(cell: unknown): string {
+  const str = cell === null || cell === undefined ? '' : String(cell)
+  // Escape quotes by doubling them, wrap in quotes
+  return `"${str.replace(/"/g, '""')}"`
+}
+
+/**
+ * Converts rows of data to CSV string format
+ * @param headers - Array of column headers
+ * @param rows - Array of row data (each row is an array of cell values)
+ * @returns CSV formatted string
+ */
+export function toCsvString(headers: string[], rows: unknown[][]): string {
+  const headerRow = headers.map(escapeCsvCell).join(',')
+  const dataRows = rows.map((row) => row.map(escapeCsvCell).join(','))
+  return [headerRow, ...dataRows].join('\n')
+}
+
+/**
+ * Triggers a browser download of CSV content
+ * @param csvContent - The CSV string content
+ * @param filename - The filename (without .csv extension)
+ */
+export function downloadCsv(csvContent: string, filename: string): void {
+  const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.setAttribute('href', url)
+  link.setAttribute('download', `${filename}.csv`)
+  link.style.visibility = 'hidden'
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+  URL.revokeObjectURL(url)
+}
+
+/**
+ * Exports data as a CSV file download
+ * @param headers - Array of column headers
+ * @param rows - Array of row data
+ * @param filename - The filename (without .csv extension)
+ */
+export function exportToCsv(headers: string[], rows: unknown[][], filename: string): void {
+  const csvContent = toCsvString(headers, rows)
+  downloadCsv(csvContent, filename)
+}

--- a/src/views/DataQualityArchivedJobsView.vue
+++ b/src/views/DataQualityArchivedJobsView.vue
@@ -12,7 +12,7 @@
             <div class="flex items-center gap-2">
               <Button
                 variant="outline"
-                @click="exportToCsv"
+                @click="exportReport"
                 :disabled="loading || !issues.length"
                 class="text-sm px-4 py-2"
               >
@@ -278,7 +278,7 @@ import {
   Clock,
 } from 'lucide-vue-next'
 import { toast } from 'vue-sonner'
-import { formatCurrency } from '@/utils/string-formatting'
+import { formatCurrency, exportToCsv } from '@/utils/string-formatting'
 
 interface ValidationIssue {
   id: string
@@ -459,7 +459,7 @@ const refreshData = async () => {
   }
 }
 
-const exportToCsv = () => {
+const exportReport = () => {
   if (!issues.value.length) return
 
   const headers = ['Job Number', 'Client', 'Issue', 'Archived Date', 'Job Value']
@@ -471,19 +471,7 @@ const exportToCsv = () => {
     formatCurrency(issue.jobValue),
   ])
 
-  const csvContent = [
-    headers.join(','),
-    ...rows.map((row) => row.map((cell) => `"${cell}"`).join(',')),
-  ].join('\n')
-
-  const blob = new Blob([csvContent], { type: 'text/csv' })
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = `archived-jobs-validation-${new Date().toISOString().split('T')[0]}.csv`
-  a.click()
-  URL.revokeObjectURL(url)
-
+  exportToCsv(headers, rows, `archived-jobs-validation-${new Date().toISOString().split('T')[0]}`)
   toast.success('Report exported successfully')
 }
 

--- a/src/views/JobAgingReportView.vue
+++ b/src/views/JobAgingReportView.vue
@@ -305,6 +305,7 @@ import {
 } from 'lucide-vue-next'
 import { jobAgingReportService } from '@/services/job-aging-report.service'
 import type { JobAgingData, JobAgingFilters, JobAgingTableColumn } from '@/types/job-aging.types'
+import { formatCurrency } from '@/utils/string-formatting'
 
 // Reactive state
 const jobs = ref<JobAgingData[]>([])
@@ -450,16 +451,7 @@ const sortBy = (column: string) => {
 }
 
 const exportToCsv = () => {
-  jobAgingReportService.exportToCsv(sortedAndFilteredJobs.value)
-}
-
-const formatCurrency = (amount: number): string => {
-  return new Intl.NumberFormat('en-NZ', {
-    style: 'currency',
-    currency: 'NZD',
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
-  }).format(amount)
+  jobAgingReportService.exportToFile(sortedAndFilteredJobs.value)
 }
 
 const getStatusBadgeClass = (status: string): string => {

--- a/src/views/KPIReportsView.vue
+++ b/src/views/KPIReportsView.vue
@@ -327,6 +327,7 @@ import MonthSelector from '@/components/kpi/MonthSelector.vue'
 import { kpiService } from '@/services/kpi.service'
 import type { KPICalendarResponse, DayKPI } from '@/services/kpi.service'
 import { BarChart3, Download, RefreshCw, Settings } from 'lucide-vue-next'
+import { formatCurrency } from '@/utils/string-formatting'
 
 const router = useRouter()
 const loading = ref(false)
@@ -493,10 +494,6 @@ const performanceVariant = computed(() => {
 
 function formatHours(hours: number): string {
   return kpiService.formatHours(hours)
-}
-
-function formatCurrency(value: number): string {
-  return kpiService.formatCurrency(value)
 }
 
 function handleDayClick(day: DayKPI) {

--- a/src/views/StaffPerformanceReportView.vue
+++ b/src/views/StaffPerformanceReportView.vue
@@ -283,6 +283,7 @@ import {
 import AppLayout from '@/components/AppLayout.vue'
 import { Button } from '@/components/ui/button'
 import { staffPerformanceReportService } from '@/services/staff-performance-report.service'
+import { formatCurrency } from '@/utils/string-formatting'
 import type {
   StaffPerformanceData,
   TeamAverages,
@@ -298,10 +299,6 @@ const dateRange = ref({
   startDate: '',
   endDate: '',
 })
-
-const formatCurrency = (value: number): string => {
-  return staffPerformanceReportService.formatCurrency(value)
-}
 
 const formatHours = (hours: number): string => {
   return staffPerformanceReportService.formatHours(hours)
@@ -389,7 +386,7 @@ const exportToCsv = () => {
   if (!teamAverages.value || staffData.value.length === 0) return
 
   const dateRangeStr = `${dateRange.value.startDate} to ${dateRange.value.endDate}`
-  staffPerformanceReportService.exportToCsv(staffData.value, teamAverages.value, dateRangeStr)
+  staffPerformanceReportService.exportToFile(staffData.value, teamAverages.value, dateRangeStr)
 }
 
 onMounted(() => {

--- a/src/views/purchasing/ItemSelect.vue
+++ b/src/views/purchasing/ItemSelect.vue
@@ -11,6 +11,7 @@ import { Badge } from '../../components/ui/badge'
 import { useStockStore, type StockItem } from '../../stores/stockStore'
 import { useCompanyDefaultsStore } from '../../stores/companyDefaults'
 import { onMounted, computed, ref } from 'vue'
+import { formatCurrency } from '@/utils/string-formatting'
 
 const props = withDefaults(
   defineProps<{
@@ -74,14 +75,6 @@ const filteredItems = computed(() => {
     return searchableFields.some((field) => field?.toLowerCase().includes(term))
   })
 })
-
-// Helper function for formatting currency
-function formatCurrency(value: number): string {
-  return new Intl.NumberFormat('en-NZ', {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  }).format(value)
-}
 
 const displayPrice = (item: StockItem) => {
   let price = '0.00'

--- a/src/views/purchasing/ProductMappingValidationView.vue
+++ b/src/views/purchasing/ProductMappingValidationView.vue
@@ -270,6 +270,7 @@ import { Package, Search, Edit, Loader2, CheckCircle, XCircle } from 'lucide-vue
 import { api } from '@/api/client'
 import { schemas } from '@/api/generated/api'
 import { z } from 'zod'
+import { formatCurrency } from '@/utils/string-formatting'
 
 type ProductMapping = z.infer<typeof schemas.ProductMapping>
 type ProductMappingValidateRequest = z.infer<typeof schemas.ProductMappingValidateRequest>
@@ -303,13 +304,6 @@ const formatInputData = (data: unknown): string => {
   if (typeof data === 'string') return data
   if (typeof data === 'object') return JSON.stringify(data)
   return String(data)
-}
-
-const formatCurrency = (value: number): string => {
-  return new Intl.NumberFormat('en-NZ', {
-    style: 'currency',
-    currency: 'NZD',
-  }).format(value)
 }
 
 const loadMappings = async () => {

--- a/src/views/purchasing/StockView.vue
+++ b/src/views/purchasing/StockView.vue
@@ -260,6 +260,7 @@ import { jobService } from '@/services/job.service'
 import { onMounted, ref, computed, watch } from 'vue'
 import { toast } from 'vue-sonner'
 import { formatMetalType } from '@/utils/metalType'
+import { formatCurrency } from '@/utils/string-formatting'
 
 const stockStore = useStockStore()
 const jobsStore = useJobsStore()
@@ -340,10 +341,6 @@ const addForm = ref({
 })
 
 function formatQuantity(value: number): string {
-  return isNaN(value) ? '0.00' : value.toFixed(2)
-}
-
-function formatCurrency(value: number): string {
   return isNaN(value) ? '0.00' : value.toFixed(2)
 }
 


### PR DESCRIPTION
…ties

- Add edit and soft-delete functionality for client contacts
  - New edit/delete buttons on ContactSelectionModal
  - Soft delete sets is_active=false instead of hard delete
  - Delete confirmation overlay before removing contacts

- Consolidate currency formatting to single NZD implementation
  - All formatCurrency calls now use centralized function from string-formatting.ts
  - Fixed JobCostAnalysisTab which was incorrectly using USD
  - Updated 30+ files to use consistent NZD/en-NZ formatting

- Consolidate CSV export utilities
  - Added exportToCsv, toCsvString, downloadCsv to string-formatting.ts
  - Proper CSV escaping (quotes are doubled per spec)
  - Updated job-aging-report, staff-performance-report, and DataQualityArchivedJobsView

- Fix API endpoint bug in contact management
  - Changed from clients_contacts_retrieve to clients_contacts_list
  - Was sending literal `:id` instead of actual UUID

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 📝 Description

_Short explanation of what you’ve built and why._

## 🔗 Related Issue

Closes #[issue-number]

## 🚀 Changes

- Bullet-list of feature additions or fixes (e.g. extracted `useChat` composable, split `ChatHistory` and `ChatInput` components, added Pinia store).
- …

## ✅ Checklist

**Vue.js (Composition API)**

- [ ] Used Composition API (`<script setup>` & composables), no heavy logic in templates
- [ ] UI logic extracted to reusable composables (`useChat`, etc.)
- [ ] Components are focused & small (<200 LOC)
- [ ] Communication via `props` and `emit`, no direct parent/child ref duplication
- [ ] State management in Pinia; no ad-hoc reactive globals
- [ ] Routes/components lazy-loaded where appropriate

**Quality & Formatting**

- [ ] Passes Prettier (`npx prettier --check .`)
- [ ] Passes ESLint with zero warnings (`npx eslint . --ext .js,.ts,.vue`)
- [ ] Added JSDoc comments for all props and emitted events
- [ ] New or updated unit/E2E tests included
