### PR TITLE
fix: consolidate remaining currency formatting to use formatCurrency

### DIFF
--- a/src/components/QuoteImportDialog.vue
+++ b/src/components/QuoteImportDialog.vue
@@ -205,10 +205,10 @@
                     <td class="px-3 py-2 text-gray-900">{{ line.desc }}</td>
                     <td class="px-3 py-2 text-right text-gray-900">{{ line.quantity }}</td>
                     <td class="px-3 py-2 text-right text-gray-900">
-                      ${{ line.unit_cost.toFixed(2) }}
+                      {{ formatCurrency(line.unit_cost) }}
                     </td>
                     <td class="px-3 py-2 text-right font-medium text-gray-900">
-                      ${{ line.total_cost.toFixed(2) }}
+                      {{ formatCurrency(line.total_cost) }}
                     </td>
                   </tr>
                 </tbody>
@@ -325,6 +325,7 @@ import { ref, computed } from 'vue'
 import { useQuoteImport } from '@/composables/useQuoteImport'
 import { z } from 'zod'
 import { schemas } from '@/api/generated/schemas'
+import { formatCurrency } from '@/utils/string-formatting'
 
 type ApplyQuoteResponse = z.infer<typeof schemas.ApplyQuoteResponse>
 

--- a/src/components/job/StockConsumptionModal.vue
+++ b/src/components/job/StockConsumptionModal.vue
@@ -125,13 +125,13 @@
             <span class="flex items-center gap-2 text-blue-700">
               <Package class="w-7 h-7 text-blue-500" />
               <span>Total cost:</span>
-              <span class="text-blue-700">${{ totalCost.toFixed(2) }}</span>
+              <span class="text-blue-700">{{ formatCurrency(totalCost) }}</span>
             </span>
             <span class="mx-6 h-10 border-l border-gray-300"></span>
             <span class="flex items-center gap-2 text-green-700">
               <DollarSign class="w-7 h-7 text-green-500" />
               <span>Total revenue:</span>
-              <span class="text-green-700">${{ totalRevenue.toFixed(2) }}</span>
+              <span class="text-green-700">{{ formatCurrency(totalRevenue) }}</span>
             </span>
           </div>
         </div>

--- a/src/components/purchasing/PendingItemsTable.vue
+++ b/src/components/purchasing/PendingItemsTable.vue
@@ -6,6 +6,7 @@ import { Checkbox } from '../ui/checkbox'
 import { ArrowDown, ArrowDownToLine } from 'lucide-vue-next'
 import { schemas } from '../../api/generated/api'
 import type { z } from 'zod'
+import { formatCurrency } from '@/utils/string-formatting'
 
 // Use generated types from API schema
 type PendingLine = z.infer<typeof schemas.PurchaseOrderLine> & {
@@ -98,7 +99,7 @@ const columns = computed(() => [
     header: 'Unit Cost',
     cell: ({ row }: DataTableRowContext) => {
       const unitCost = row.original.unit_cost
-      return unitCost ? `$${unitCost.toFixed(2)}` : 'N/A'
+      return unitCost ? formatCurrency(unitCost) : 'N/A'
     },
   },
 ])

--- a/src/components/purchasing/ReceivedItemsTable.vue
+++ b/src/components/purchasing/ReceivedItemsTable.vue
@@ -9,6 +9,7 @@ import { ArrowUp, ArrowUpToLine } from 'lucide-vue-next'
 import { toast } from 'vue-sonner'
 import { schemas } from '../../api/generated/api'
 import type { z } from 'zod'
+import { formatCurrency } from '@/utils/string-formatting'
 
 // Use generated types from API schema
 type Job = z.infer<typeof schemas.Job>
@@ -220,7 +221,7 @@ const columns = computed(() => [
     id: 'unit_cost',
     header: 'Unit Cost',
     cell: ({ row }: DataTableRowContext) =>
-      row.original.unit_cost ? `$${row.original.unit_cost.toFixed(2)}` : 'N/A',
+      row.original.unit_cost ? formatCurrency(row.original.unit_cost) : 'N/A',
   },
   {
     id: 'retail_rate',

--- a/src/components/timesheet/SummaryDrawer.vue
+++ b/src/components/timesheet/SummaryDrawer.vue
@@ -44,7 +44,7 @@
                   <div class="min-w-0">
                     <p class="text-xs md:text-sm text-gray-600">Total Bill</p>
                     <p class="text-base md:text-lg font-semibold">
-                      ${{ consolidatedSummary.totalBill.toFixed(2) }}
+                      {{ formatCurrency(consolidatedSummary.totalBill) }}
                     </p>
                   </div>
                 </div>
@@ -144,7 +144,9 @@
                     <div class="flex justify-between items-center pt-2 border-t border-gray-100">
                       <div class="text-sm">
                         <span class="text-gray-600">Total Bill:</span>
-                        <span class="font-semibold ml-1">${{ jobData.totalBill.toFixed(2) }}</span>
+                        <span class="font-semibold ml-1">{{
+                          formatCurrency(jobData.totalBill)
+                        }}</span>
                       </div>
                       <ExternalLink class="h-4 w-4 text-gray-400" />
                     </div>
@@ -195,6 +197,7 @@ import { api } from '@/api/client'
 import type { TimesheetEntryWithMeta } from '@/constants/timesheet'
 import { debugLog } from '../../utils/debug'
 import { z } from 'zod'
+import { formatCurrency } from '@/utils/string-formatting'
 
 type ModernTimesheetJob = z.infer<typeof schemas.ModernTimesheetJob>
 type FullJob = z.infer<typeof schemas.Job>

--- a/src/views/JobView.vue
+++ b/src/views/JobView.vue
@@ -330,6 +330,7 @@ import { useJobFinancials } from '../composables/useJobFinancials'
 import { useCompanyDefaultsStore } from '../stores/companyDefaults'
 import { api } from '../api/client'
 import { ArrowLeft, Printer, Download } from 'lucide-vue-next'
+import { formatCurrency } from '@/utils/string-formatting'
 import { JOB_STATUS_CHOICES } from '../constants/job-status'
 import { jobService } from '../services/job.service'
 import { toast } from 'vue-sonner'
@@ -458,7 +459,7 @@ const handleRejectedChange = async () => {
       if (financials.toBeInvoiced > 0) {
         // Show warning but allow proceeding
         const confirmed = confirm(
-          `Warning: Job has $${financials.toBeInvoiced.toFixed(2)} still to be invoiced. Are you sure you want to reject?`,
+          `Warning: Job has ${formatCurrency(financials.toBeInvoiced)} still to be invoiced. Are you sure you want to reject?`,
         )
 
         if (!confirmed) {

--- a/src/views/TimesheetEntryView.vue
+++ b/src/views/TimesheetEntryView.vue
@@ -448,9 +448,9 @@
                       <div class="flex justify-between items-center pt-2 border-t border-gray-100">
                         <div class="text-xs">
                           <span class="text-gray-600">Bill:</span>
-                          <span class="font-semibold ml-1"
-                            >${{ jobData.totalBill.toFixed(2) }}</span
-                          >
+                          <span class="font-semibold ml-1">{{
+                            formatCurrency(jobData.totalBill)
+                          }}</span>
                         </div>
                         <ExternalLink class="h-3 w-3 text-gray-400" />
                       </div>
@@ -489,7 +489,7 @@
                           <div class="min-w-0">
                             <p class="text-sm text-gray-600">Total Bill</p>
                             <p class="text-lg font-semibold">
-                              ${{ consolidatedSummary.totalBill.toFixed(2) }}
+                              {{ formatCurrency(consolidatedSummary.totalBill) }}
                             </p>
                           </div>
                         </div>
@@ -569,6 +569,7 @@ import {
 import { useTimesheetAutosave } from '@/composables/useTimesheetAutosave'
 import { useTimesheetSummary } from '@/composables/useTimesheetSummary'
 import { toast } from 'vue-sonner'
+import { formatCurrency } from '@/utils/string-formatting'
 
 import { useTimesheetEntryGrid } from '@/composables/useTimesheetEntryGrid'
 import { useTimesheetStore } from '@/stores/timesheet'


### PR DESCRIPTION
Update 7 files that were still using ${{ value.toFixed(2) }} pattern to use the centralized formatCurrency utility with NZD/en-NZ locale.

Files updated:
- TimesheetEntryView.vue
- SummaryDrawer.vue
- JobView.vue
- QuoteImportDialog.vue
- ReceivedItemsTable.vue
- PendingItemsTable.vue
- StockConsumptionModal.vue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 📝 Description

_Short explanation of what you’ve built and why._

## 🔗 Related Issue

Closes #[issue-number]

## 🚀 Changes

- Bullet-list of feature additions or fixes (e.g. extracted `useChat` composable, split `ChatHistory` and `ChatInput` components, added Pinia store).
- …

## ✅ Checklist

**Vue.js (Composition API)**

- [ ] Used Composition API (`<script setup>` & composables), no heavy logic in templates
- [ ] UI logic extracted to reusable composables (`useChat`, etc.)
- [ ] Components are focused & small (<200 LOC)
- [ ] Communication via `props` and `emit`, no direct parent/child ref duplication
- [ ] State management in Pinia; no ad-hoc reactive globals
- [ ] Routes/components lazy-loaded where appropriate

**Quality & Formatting**

- [ ] Passes Prettier (`npx prettier --check .`)
- [ ] Passes ESLint with zero warnings (`npx eslint . --ext .js,.ts,.vue`)
- [ ] Added JSDoc comments for all props and emitted events
- [ ] New or updated unit/E2E tests included
