### PR TITLE
fix(ui): correct swapped automation-ids for mobile/desktop header elements

### DIFF
--- a/src/views/JobView.vue
+++ b/src/views/JobView.vue
@@ -53,7 +53,7 @@
                   :options="JOB_STATUS_CHOICES"
                   @update:value="handleStatusUpdate"
                   placeholder="Status"
-                  automation-id="header-job-status"
+                  automation-id="header-job-status-mobile"
                 />
               </div>
               <span>•</span>
@@ -63,7 +63,7 @@
                   :value="localPricingMethodology"
                   :options="pricingMethodologyOptions"
                   @update:value="handlePricingMethodologyUpdate"
-                  automation-id="header-pricing-method"
+                  automation-id="header-pricing-method-mobile"
                 />
               </div>
               <template v-if="jobDataWithPaid?.quoted">
@@ -172,7 +172,7 @@
                     :options="JOB_STATUS_CHOICES"
                     @update:value="handleStatusUpdate"
                     placeholder="Select Status"
-                    automation-id="header-job-status-mobile"
+                    automation-id="header-job-status"
                   />
                 </div>
                 <span>•</span>
@@ -183,7 +183,7 @@
                     :options="pricingMethodologyOptions"
                     @update:value="handlePricingMethodologyUpdate"
                     placeholder="Select methodology"
-                    automation-id="header-pricing-method-mobile"
+                    automation-id="header-pricing-method"
                   />
                 </div>
                 <template v-if="jobDataWithPaid?.quoted">


### PR DESCRIPTION
## Summary
- Fixed incorrectly swapped automation-ids in JobView.vue header section
- Desktop view elements now use `header-job-status` and `header-pricing-method`
- Mobile view elements now use `header-job-status-mobile` and `header-pricing-method-mobile`

## Problem
E2E tests were failing because Playwright (using desktop viewport) was finding header elements in the mobile section (which is hidden via `md:hidden` CSS class). The automation-ids were backwards - mobile section had desktop ids and vice versa.

## Test plan
- [x] All 14 edit-job-settings E2E tests pass
- [x] Reload stability test confirms no data drift after multiple page reloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)