### PR TITLE
feat(test): add E2E tests for estimate entry creation

### DIFF
--- a/schema.yml
+++ b/schema.yml
@@ -11763,11 +11763,13 @@ components:
         - purchase_order
         - split_from_stock
         - manual
+        - product_catalog
       type: string
       description: |-
         * `purchase_order` - Purchase Order Receipt
         * `split_from_stock` - Split/Offcut from Stock
         * `manual` - Manual Adjustment/Stocktake
+        * `product_catalog` - Product Catalog
     SpeedQualityTradeoffEnum:
       enum:
         - fast
@@ -12725,6 +12727,7 @@ components:
             * `purchase_order` - Purchase Order Receipt
             * `split_from_stock` - Split/Offcut from Stock
             * `manual` - Manual Adjustment/Stocktake
+            * `product_catalog` - Product Catalog
         location:
           type: string
           description: Where we are keeping this

--- a/src/api/generated/api.ts
+++ b/src/api/generated/api.ts
@@ -2142,7 +2142,7 @@ const AllocationDeleteResponse = z
 const PurchasingErrorResponse = z
   .object({ error: z.string(), details: z.string().optional() })
   .passthrough()
-const SourceEnum = z.enum(['purchase_order', 'split_from_stock', 'manual'])
+const SourceEnum = z.enum(['purchase_order', 'split_from_stock', 'manual', 'product_catalog'])
 const StockItem = z
   .object({
     id: z.string().uuid(),

--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -55,9 +55,10 @@ const colCount = computed(() => props.columns.length)
       <TableBody class="overflow-y-auto">
         <template v-if="table.getRowModel().rows.length">
           <TableRow
-            v-for="row in table.getRowModel().rows"
+            v-for="(row, rowIndex) in table.getRowModel().rows"
             :key="row.id"
             class="hover:bg-slate-50 cursor-pointer"
+            :data-automation-id="`cost-line-row-${rowIndex}`"
             @click="emit('rowClick', row.original)"
           >
             <TableCell v-for="cell in row.getVisibleCells()" :key="cell.id" class="p-1">

--- a/src/components/shared/SmartCostLinesTable.vue
+++ b/src/components/shared/SmartCostLinesTable.vue
@@ -25,6 +25,7 @@ import ItemSelect from '../../views/purchasing/ItemSelect.vue'
 import type { DataTableRowContext } from '../../utils/data-table-types'
 import { toast } from 'vue-sonner'
 import { debugLog } from '../../utils/debug'
+import { formatCurrency } from '../../utils/string-formatting'
 import { HelpCircle, Trash2, Plus, AlertTriangle } from 'lucide-vue-next'
 import {
   Dialog,
@@ -264,14 +265,6 @@ function getKindBadge(line: CostLine) {
     default:
       return { label: kind, class: 'bg-gray-100 text-gray-800' }
   }
-}
-
-function formatMoney(n: number | undefined | null) {
-  const val = Number(n ?? 0)
-  return new Intl.NumberFormat('en-NZ', {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  }).format(val)
 }
 
 function formatModifiedDate(dateString: string): string {
@@ -957,7 +950,7 @@ const columns = computed(() => {
         return h(
           'div',
           { class: 'col-12ch text-right font-medium numeric-text' },
-          `$${formatMoney(totalCost)}`,
+          formatCurrency(totalCost),
         )
       },
       meta: { editable: false },
@@ -975,7 +968,7 @@ const columns = computed(() => {
         return h(
           'div',
           { class: 'col-12ch text-right font-medium numeric-text' },
-          `$${formatMoney(totalRev)}`,
+          formatCurrency(totalRev),
         )
       },
       meta: { editable: false },
@@ -1267,7 +1260,13 @@ const shortcutsTitle = computed(
     </div>
 
     <div v-if="!props.readOnly" class="px-4 py-2">
-      <Button variant="default" size="sm" @click="handleAddLine" aria-label="Add Row">
+      <Button
+        variant="default"
+        size="sm"
+        @click="handleAddLine"
+        aria-label="Add Row"
+        data-automation-id="cost-lines-add-row"
+      >
         <Plus class="w-4 h-4 mr-1" /> Add row
       </Button>
     </div>

--- a/src/views/purchasing/ItemSelect.vue
+++ b/src/views/purchasing/ItemSelect.vue
@@ -118,7 +118,7 @@ const displayPrice = (item: StockItem) => {
       }
     "
   >
-    <SelectTrigger class="h-10 item-select-trigger">
+    <SelectTrigger class="h-10 item-select-trigger" data-automation-id="item-select-trigger">
       <SelectValue :placeholder="'Select Item'" />
     </SelectTrigger>
 
@@ -145,6 +145,7 @@ const displayPrice = (item: StockItem) => {
           :key="i.id || 'unknown'"
           :value="i.id || ''"
           class="cursor-pointer p-4 border-b border-border last:border-b-0 hover:bg-accent/50 focus:bg-accent/50 bg-background w-full"
+          :data-automation-id="`item-select-option-${i.id === '__labour__' ? 'labour' : i.item_code || i.id}`"
         >
           <div class="flex w-full items-start justify-between gap-6 !min-w-[500px]">
             <div class="flex-1 min-w-0">
@@ -166,7 +167,7 @@ const displayPrice = (item: StockItem) => {
                 variant="secondary"
                 class="text-xs font-semibold"
               >
-                ${{ displayPrice(i) }}
+                {{ displayPrice(i) }}
               </Badge>
               <Badge v-else variant="secondary" class="text-xs"> No price </Badge>
 

--- a/tests/job/create-estimate-entry.spec.ts
+++ b/tests/job/create-estimate-entry.spec.ts
@@ -1,0 +1,284 @@
+import { test, expect } from '../fixtures/auth'
+import type { Page } from '@playwright/test'
+import { autoId, dismissToasts, waitForAutosave } from '../fixtures/helpers'
+
+/**
+ * Tests for creating estimate entries on the Estimate tab.
+ * These tests verify:
+ * - Adding Labour entries
+ * - Adding Material entries (using search)
+ * - Adding Adjustment entries
+ */
+test.describe.serial('create estimate entries', () => {
+  // Store job URL from the first test to use in subsequent tests
+  let createdJobUrl: string
+
+  // Helper to find a row by exact description match in textarea
+  async function findRowByDescription(page: Page, description: string) {
+    const rows = page.locator('[data-automation-id^="cost-line-row-"]')
+    const rowCount = await rows.count()
+    for (let i = 0; i < rowCount; i++) {
+      const row = rows.nth(i)
+      const textarea = row.locator('textarea').first()
+      const value = await textarea.inputValue().catch(() => '')
+      if (value === description) {
+        return row
+      }
+    }
+    return null
+  }
+
+  test('create a job for estimate testing', async ({ authenticatedPage: page }) => {
+    const timestamp = Date.now()
+    const jobName = `Estimate Test Job ${timestamp}`
+
+    await test.step('navigate to create job page', async () => {
+      await autoId(page, 'nav-create-job').click()
+      await page.waitForURL('**/jobs/create')
+    })
+
+    await test.step('search and select client', async () => {
+      const clientInput = autoId(page, 'client-search-input')
+      await clientInput.fill('ABC')
+      await autoId(page, 'client-search-results').waitFor({ timeout: 10000 })
+      await page.getByRole('option', { name: /ABC Carpet Cleaning TEST IGNORE/ }).click()
+      await expect(clientInput).toHaveValue('ABC Carpet Cleaning TEST IGNORE')
+    })
+
+    await test.step('enter job details', async () => {
+      await autoId(page, 'job-name-input').fill(jobName)
+      // Use 0 for ballpark estimates to avoid pre-created rows
+      await autoId(page, 'estimated-materials-input').fill('0')
+      await autoId(page, 'estimated-time-input').fill('0')
+    })
+
+    await test.step('select or create contact', async () => {
+      await autoId(page, 'contact-modal-button').click({ timeout: 10000 })
+      await autoId(page, 'contact-selection-modal').waitFor({ timeout: 10000 })
+
+      const selectButtons = autoId(page, 'contact-select-button')
+      const selectButtonCount = await selectButtons.count()
+
+      if (selectButtonCount > 0) {
+        await selectButtons.first().click()
+      } else {
+        const submitButton = autoId(page, 'contact-form-submit')
+        await expect(submitButton).toHaveText('Create Contact', { timeout: 10000 })
+        await autoId(page, 'contact-form-name').fill(`Test Contact ${timestamp}`)
+        await autoId(page, 'contact-form-email').fill(`test${timestamp}@example.com`)
+        await submitButton.click()
+      }
+
+      await autoId(page, 'contact-selection-modal').waitFor({ state: 'hidden', timeout: 10000 })
+    })
+
+    await test.step('set pricing method to T&M and submit', async () => {
+      // Use T&M so we land on the Estimate tab
+      await autoId(page, 'pricing-method-select').selectOption('time_materials')
+
+      await dismissToasts(page)
+
+      await autoId(page, 'create-job-submit').click({ force: true })
+      await page.waitForURL('**/jobs/*?*tab=estimate*', { timeout: 15000 })
+
+      createdJobUrl = page.url()
+      console.log(`Created job at: ${createdJobUrl}`)
+    })
+  })
+
+  test('add Labour entry', async ({ authenticatedPage: page }) => {
+    await page.goto(createdJobUrl)
+    await page.waitForLoadState('networkidle')
+
+    // Make sure we're on the Estimate tab
+    await autoId(page, 'tab-estimate').click()
+    await page.waitForTimeout(1000) // Wait for tab content to load
+
+    await test.step('click Add row button', async () => {
+      await autoId(page, 'cost-lines-add-row').waitFor({ timeout: 10000 })
+      await autoId(page, 'cost-lines-add-row').click()
+    })
+
+    await test.step('select Labour from item dropdown', async () => {
+      // The dropdown auto-opens when a new row is added
+      // Wait for options to appear
+      const labourOption = autoId(page, 'item-select-option-labour')
+      await labourOption.waitFor({ timeout: 10000 })
+      await labourOption.click()
+    })
+
+    await test.step('verify Labour was selected and update quantity', async () => {
+      // Wait for the table to update after selection
+      await page.waitForTimeout(1000)
+
+      // Find the row with exact description "Labour"
+      const labourRow = await findRowByDescription(page, 'Labour')
+      expect(labourRow).not.toBeNull()
+      console.log('Found Labour row with exact description match')
+
+      // Click on this row to select it, then update quantity
+      await labourRow!.click()
+
+      // The quantity input in the row
+      const qtyInput = labourRow!.locator('input').first()
+      await qtyInput.click()
+      await qtyInput.fill('2')
+      await page.keyboard.press('Tab')
+    })
+
+    await test.step('wait for autosave', async () => {
+      await waitForAutosave(page)
+    })
+
+    await test.step('verify Labour entry was saved', async () => {
+      await page.reload()
+      await autoId(page, 'tab-estimate').click()
+      await page.waitForTimeout(1000)
+
+      // Verify Labour row exists with exact description
+      const labourRow = await findRowByDescription(page, 'Labour')
+      expect(labourRow).not.toBeNull()
+    })
+  })
+
+  test('add Material entry using search', async ({ authenticatedPage: page }) => {
+    await page.goto(createdJobUrl)
+    await page.waitForLoadState('networkidle')
+
+    await autoId(page, 'tab-estimate').click()
+    await page.waitForTimeout(1000)
+
+    await test.step('click Add row button', async () => {
+      await autoId(page, 'cost-lines-add-row').waitFor({ timeout: 10000 })
+      await autoId(page, 'cost-lines-add-row').click()
+    })
+
+    await test.step('search for M8 ZINC and select the wing nut', async () => {
+      // The dropdown auto-opens - need to click into the search input
+      const searchInput = page.getByPlaceholder('Search items by description, code, or type...')
+      await searchInput.waitFor({ timeout: 10000 })
+      await searchInput.click()
+      await searchInput.fill('M8 ZINC')
+
+      // Wait for filtered results and select the wing nut option
+      const wingNutOption = page
+        .locator('[data-automation-id^="item-select-option-"]')
+        .filter({ hasText: 'M8 ZINC WING NUT' })
+      await wingNutOption.waitFor({ timeout: 10000 })
+      await wingNutOption.click()
+    })
+
+    await test.step('verify material was selected and update quantity', async () => {
+      // Wait for the table to update
+      await page.waitForTimeout(2000)
+
+      // Find the row with exact description "M8 ZINC WING NUT"
+      const materialRow = await findRowByDescription(page, 'M8 ZINC WING NUT')
+      expect(materialRow).not.toBeNull()
+      console.log('Found M8 ZINC WING NUT row with exact description match')
+
+      // Update quantity
+      const qtyInput = materialRow!.locator('input').first()
+      await qtyInput.click()
+      await qtyInput.fill('10')
+      await page.keyboard.press('Tab')
+    })
+
+    await test.step('wait for autosave', async () => {
+      await waitForAutosave(page)
+    })
+
+    await test.step('verify Material entry was saved', async () => {
+      await page.reload()
+      await autoId(page, 'tab-estimate').click()
+      await page.waitForTimeout(1000)
+
+      // Verify row exists with exact description
+      const materialRow = await findRowByDescription(page, 'M8 ZINC WING NUT')
+      expect(materialRow).not.toBeNull()
+    })
+  })
+
+  test('add Adjustment entry', async ({ authenticatedPage: page }) => {
+    await page.goto(createdJobUrl)
+    await page.waitForLoadState('networkidle')
+
+    await autoId(page, 'tab-estimate').click()
+    await page.waitForTimeout(1000)
+
+    // Count existing rows before adding
+    const rowsBefore = await page.locator('[data-automation-id^="cost-line-row-"]').count()
+    console.log(`Rows before adding adjustment: ${rowsBefore}`)
+
+    await test.step('click Add row button', async () => {
+      await autoId(page, 'cost-lines-add-row').waitFor({ timeout: 10000 })
+      await autoId(page, 'cost-lines-add-row').click()
+    })
+
+    await test.step('close the item dropdown and fill adjustment details manually', async () => {
+      // Press Escape to close the auto-opened dropdown
+      await page.keyboard.press('Escape')
+      await page.waitForTimeout(500)
+
+      // Find the newly added row (should be the last one)
+      const rows = page.locator('[data-automation-id^="cost-line-row-"]')
+      const newRow = rows.last()
+
+      // Click on description input and fill it
+      const descInput = newRow.locator('textarea').first()
+      await descInput.click()
+      await descInput.fill('Discount - repeat customer')
+      await page.keyboard.press('Tab')
+
+      // Fill quantity
+      await page.keyboard.type('1')
+      await page.keyboard.press('Tab')
+
+      // Fill unit cost (negative for discount)
+      await page.keyboard.type('-50')
+      await page.keyboard.press('Tab')
+
+      // Fill unit revenue (also negative)
+      await page.keyboard.type('-50')
+      await page.keyboard.press('Tab')
+    })
+
+    await test.step('wait for autosave', async () => {
+      await waitForAutosave(page)
+    })
+
+    await test.step('verify Adjustment entry was saved', async () => {
+      await page.reload()
+      await autoId(page, 'tab-estimate').click()
+      await page.waitForTimeout(1000)
+
+      // Verify row exists with exact description
+      const adjustmentRow = await findRowByDescription(page, 'Discount - repeat customer')
+      expect(adjustmentRow).not.toBeNull()
+    })
+  })
+
+  test('verify all entries persist after reload', async ({ authenticatedPage: page }) => {
+    await page.goto(createdJobUrl)
+    await page.waitForLoadState('networkidle')
+
+    await autoId(page, 'tab-estimate').click()
+    await page.waitForTimeout(1000)
+
+    await test.step('verify all 3 entry types exist', async () => {
+      // Verify each entry type is present with exact description matches
+      const labourRow = await findRowByDescription(page, 'Labour')
+      const materialRow = await findRowByDescription(page, 'M8 ZINC WING NUT')
+      const adjustmentRow = await findRowByDescription(page, 'Discount - repeat customer')
+
+      expect(labourRow).not.toBeNull()
+      expect(materialRow).not.toBeNull()
+      expect(adjustmentRow).not.toBeNull()
+
+      console.log('All 3 entry types verified with exact description matches:')
+      console.log('  - Labour')
+      console.log('  - M8 ZINC WING NUT')
+      console.log('  - Discount - repeat customer')
+    })
+  })
+})


### PR DESCRIPTION
- Add tests for Labour, Material, and Adjustment entries on Estimate tab
- Fix $$ display bug in ItemSelect.vue (formatCurrency already includes $)
- Replace local formatMoney with shared formatCurrency in SmartCostLinesTable
- Add automation-ids to DataTable rows and ItemSelect for testability
- Regenerate API from updated backend schema (stock source field fix)

Tests verify:
- Adding Labour entry via item dropdown
- Adding Material entry via search (M8 ZINC WING NUT)
- Adding Adjustment entry manually with negative values
- All entries persist after page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 📝 Description

_Short explanation of what you’ve built and why._

## 🔗 Related Issue

Closes #[issue-number]

## 🚀 Changes

- Bullet-list of feature additions or fixes (e.g. extracted `useChat` composable, split `ChatHistory` and `ChatInput` components, added Pinia store).
- …

## ✅ Checklist

**Vue.js (Composition API)**

- [ ] Used Composition API (`<script setup>` & composables), no heavy logic in templates
- [ ] UI logic extracted to reusable composables (`useChat`, etc.)
- [ ] Components are focused & small (<200 LOC)
- [ ] Communication via `props` and `emit`, no direct parent/child ref duplication
- [ ] State management in Pinia; no ad-hoc reactive globals
- [ ] Routes/components lazy-loaded where appropriate

**Quality & Formatting**

- [ ] Passes Prettier (`npx prettier --check .`)
- [ ] Passes ESLint with zero warnings (`npx eslint . --ext .js,.ts,.vue`)
- [ ] Added JSDoc comments for all props and emitted events
- [ ] New or updated unit/E2E tests included
