### PR TITLE
feat(e2e): add automation IDs for timesheet testing

### DIFF
--- a/src/components/job/JobActualTab.vue
+++ b/src/components/job/JobActualTab.vue
@@ -27,7 +27,10 @@
           <span class="text-[11px] uppercase tracking-wide text-slate-600">Quote</span>
           <strong class="tabular-nums text-slate-900">{{ formatCurrency(quoteTotal) }}</strong>
         </li>
-        <li class="h-10 px-3 rounded-lg border border-slate-200 bg-white flex items-center gap-2">
+        <li
+          data-automation-id="actual-time-expenses"
+          class="h-10 px-3 rounded-lg border border-slate-200 bg-white flex items-center gap-2"
+        >
           <span class="w-1.5 h-6 rounded-full bg-emerald-500"></span>
           <span class="text-[11px] uppercase tracking-wide text-slate-600">Time & Expenses</span>
           <strong class="tabular-nums text-slate-900">{{ formatCurrency(timeAndExpenses) }}</strong>

--- a/src/components/timesheet/StaffRow.vue
+++ b/src/components/timesheet/StaffRow.vue
@@ -71,7 +71,11 @@
     </div>
   </div>
 
-  <tr v-else class="hover:bg-gray-50 transition-colors duration-150">
+  <tr
+    v-else
+    :data-automation-id="`daily-timesheet-staff-row-${staff.staff_id}`"
+    class="hover:bg-gray-50 transition-colors duration-150"
+  >
     <td class="px-1.5 lg:px-2 py-1.5 lg:py-2 whitespace-nowrap">
       <div class="flex items-center space-x-1.5 lg:space-x-2">
         <div class="flex-shrink-0">
@@ -85,6 +89,7 @@
         </div>
         <div class="min-w-0 flex-1">
           <div
+            :data-automation-id="`daily-timesheet-staff-name-${staff.staff_id}`"
             class="text-sm lg:text-base font-medium text-gray-900 truncate cursor-pointer hover:text-blue-600 transition-colors"
             @click="openTimesheet"
           >

--- a/src/components/timesheet/TimesheetEntryJobCellEditor.ts
+++ b/src/components/timesheet/TimesheetEntryJobCellEditor.ts
@@ -85,6 +85,7 @@ export class TimesheetEntryJobCellEditor implements ICellEditor {
 
     this.input = document.createElement('input')
     this.input.type = 'text'
+    this.input.setAttribute('data-automation-id', 'timesheet-job-search')
     // Show job number if a job is selected, otherwise show the raw value
     this.input.value = this.selectedJob ? String(this.selectedJob.job_number) : this.value
     this.input.placeholder = 'Search jobs... (start typing job number or name)'
@@ -102,6 +103,7 @@ export class TimesheetEntryJobCellEditor implements ICellEditor {
 
     this.dropdown = document.createElement('div')
     this.dropdown.className = 'job-dropdown'
+    this.dropdown.setAttribute('data-automation-id', 'timesheet-job-dropdown')
     this.dropdown.style.cssText = `
       position: fixed;
       max-height: 300px;
@@ -203,6 +205,7 @@ export class TimesheetEntryJobCellEditor implements ICellEditor {
       const item = document.createElement('div')
       item.className = 'job-dropdown-item'
       item.dataset.index = String(index)
+      item.setAttribute('data-automation-id', `timesheet-job-option-${job.job_number}`)
 
       const searchTerm = this.input.value.toLowerCase()
 

--- a/src/views/JobView.vue
+++ b/src/views/JobView.vue
@@ -13,7 +13,9 @@
           </div>
           <div class="mb-3">
             <div class="flex items-center gap-2 mb-1" :key="titleKey">
-              <span class="text-xl font-bold text-gray-900">Job #{{ jobHeader?.job_number }}</span>
+              <span data-automation-id="job-number-mobile" class="text-xl font-bold text-gray-900"
+                >Job #{{ jobHeader?.job_number }}</span
+              >
               <div class="group">
                 <InlineEditText
                   v-if="jobDataWithPaid"
@@ -131,7 +133,7 @@
             </button>
             <div class="flex flex-col justify-center h-full">
               <div class="flex items-center" :key="titleKey">
-                <span class="text-xl font-bold text-gray-900"
+                <span data-automation-id="job-number" class="text-xl font-bold text-gray-900"
                   >Job #{{ jobHeader?.job_number }} -</span
                 >
                 <div class="group">

--- a/src/views/TimesheetEntryView.vue
+++ b/src/views/TimesheetEntryView.vue
@@ -244,6 +244,7 @@
             </div>
 
             <Button
+              data-automation-id="timesheet-add-entry"
               @click="addNewEntry"
               size="sm"
               variant="default"

--- a/tests/timesheet/create-timesheet-entry.spec.ts
+++ b/tests/timesheet/create-timesheet-entry.spec.ts
@@ -1,0 +1,137 @@
+import { test, expect } from '../fixtures/auth'
+import type { Page } from '@playwright/test'
+import { autoId, waitForAutosave, createTestJob } from '../fixtures/helpers'
+
+/**
+ * Tests for timesheet entry operations.
+ * Creates a job, adds time via daily timesheet, verifies on job's Actuals tab.
+ */
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+async function navigateToActualsTab(page: Page, jobUrl: string): Promise<void> {
+  const baseUrl = jobUrl.split('?')[0]
+  await page.goto(baseUrl)
+  await page.waitForLoadState('networkidle')
+  await autoId(page, 'tab-actual').click()
+  await page.waitForLoadState('networkidle')
+  await page.waitForTimeout(2000)
+}
+
+async function getTimeAndExpensesValue(page: Page): Promise<number> {
+  const chip = autoId(page, 'actual-time-expenses')
+  const text = await chip.innerText()
+  // Extract number from text like "$123.45"
+  const match = text.match(/\$?([\d,]+\.?\d*)/)
+  return match ? parseFloat(match[1].replace(/,/g, '')) : 0
+}
+
+// ============================================================================
+// Test Suite: Timesheet Entry Operations
+// ============================================================================
+
+test.describe.serial('timesheet entry operations', () => {
+  let jobUrl: string
+  let jobNumber: string
+
+  test.beforeAll(async ({ browser }) => {
+    const context = await browser.newContext()
+    const page = await context.newPage()
+
+    // Login
+    const username = process.env.E2E_TEST_USERNAME
+    const password = process.env.E2E_TEST_PASSWORD
+    await page.goto('/login')
+    await page.locator('#username').fill(username!)
+    await page.locator('#password').fill(password!)
+    await page.getByRole('button', { name: 'Sign In' }).click()
+    await page.waitForURL('**/kanban')
+
+    // Create a job for timesheet testing
+    jobUrl = await createTestJob(page, 'Timesheet')
+    console.log(`Created job at: ${jobUrl}`)
+
+    // Extract job number from the page
+    await page.goto(jobUrl.split('?')[0])
+    await page.waitForLoadState('networkidle')
+    const jobNumberElement = autoId(page, 'job-number').first()
+    await jobNumberElement.waitFor({ timeout: 10000 })
+    const jobNumberText = await jobNumberElement.innerText()
+    const match = jobNumberText.match(/#(\d+)/)
+    jobNumber = match ? match[1] : ''
+    console.log(`Extracted job number: ${jobNumber}`)
+    if (!jobNumber) {
+      throw new Error(`Failed to extract job number from: "${jobNumberText}"`)
+    }
+
+    await context.close()
+  })
+
+  test('verify initial Time & Expenses is zero', async ({ authenticatedPage: page }) => {
+    await navigateToActualsTab(page, jobUrl)
+
+    const timeExpenses = await getTimeAndExpensesValue(page)
+    console.log(`Initial Time & Expenses: $${timeExpenses}`)
+    expect(timeExpenses).toBe(0)
+  })
+
+  test('add timesheet entry for the test job', async ({ authenticatedPage: page }) => {
+    // Navigate to daily timesheet
+    await page.goto('/timesheets/daily')
+    await page.waitForLoadState('networkidle')
+
+    // Click first staff name to open their timesheet entry view
+    const firstStaffName = page
+      .locator('[data-automation-id^="daily-timesheet-staff-name-"]')
+      .first()
+    await firstStaffName.waitFor({ timeout: 10000 })
+    await firstStaffName.click()
+
+    // Wait for timesheet entry view
+    await page.waitForURL('**/timesheets/entry**')
+    await page.waitForLoadState('networkidle')
+    await page.waitForTimeout(1000)
+
+    // Click Add Entry button
+    await autoId(page, 'timesheet-add-entry').click()
+    await page.waitForTimeout(500)
+
+    // Click on the job cell (col-id="jobNumber") to open the job selector
+    const jobCell = page.locator('.ag-row').last().locator('[col-id="jobNumber"]')
+    await jobCell.click()
+    await page.waitForTimeout(300)
+
+    // Type the job number in the search input
+    const jobSearchInput = autoId(page, 'timesheet-job-search')
+    await jobSearchInput.waitFor({ timeout: 5000 })
+    await jobSearchInput.fill(jobNumber)
+    await page.waitForTimeout(500)
+
+    // Select the job from the dropdown
+    const jobOption = autoId(page, `timesheet-job-option-${jobNumber}`)
+    await jobOption.waitFor({ timeout: 5000 })
+    await jobOption.click()
+    await page.waitForTimeout(500)
+
+    // Enter hours in the hours cell (col-id="hours")
+    const hoursCell = page.locator('.ag-row').last().locator('[col-id="hours"]')
+    await hoursCell.click()
+    await page.waitForTimeout(200)
+    await page.keyboard.type('2')
+    await page.keyboard.press('Tab')
+
+    await waitForAutosave(page)
+    console.log(`Added 2 hours to job ${jobNumber}`)
+  })
+
+  test('verify timesheet entry appears on job Actuals tab', async ({ authenticatedPage: page }) => {
+    await navigateToActualsTab(page, jobUrl)
+
+    // Time & Expenses should now be > 0
+    const timeExpenses = await getTimeAndExpensesValue(page)
+    console.log(`Time & Expenses after entry: $${timeExpenses}`)
+    expect(timeExpenses).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
## Summary
- Add data-automation-id attributes for reliable E2E test selectors across timesheet and job views
- Add initial timesheet entry E2E test structure

## Automation IDs Added
- `job-number` / `job-number-mobile` on JobView
- `actual-time-expenses` on JobActualTab KPI chip
- `daily-timesheet-staff-row-{id}` and `daily-timesheet-staff-name-{id}` on StaffRow
- `timesheet-job-search`, `timesheet-job-dropdown`, `timesheet-job-option-{number}` on job cell editor
- `timesheet-add-entry` on Add Entry button

## Test Status
⚠️ **1 test failing**: The "add timesheet entry for the test job" test is not yet passing - the ag-Grid cell interaction needs more work. The infrastructure for testing is in place.

## Test plan
- [x] Verify automation IDs are present in DOM
- [ ] Complete ag-Grid cell interaction for timesheet entry (WIP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)