### PR TITLE
feat: add universal search parameter for advanced job search

### DIFF
--- a/schema.yml
+++ b/schema.yml
@@ -2485,6 +2485,12 @@ paths:
             type: string
           description: Filter by paid status
         - in: query
+          name: q
+          schema:
+            type: string
+          description: Universal search - searches across job number, name, description,
+            and client name with OR logic
+        - in: query
           name: rejected_flag
           schema:
             type: string
@@ -3566,6 +3572,72 @@ paths:
               schema:
                 $ref: '#/components/schemas/JobRestErrorResponse'
           description: ''
+  /job/rest/jobs/{job_id}/jsa/:
+    get:
+      operationId: listJobJSAs
+      description: List all JSAs for a specific job
+      parameters:
+        - in: path
+          name: job_id
+          schema:
+            type: string
+            format: uuid
+          required: true
+      tags:
+        - job
+      security:
+        - cookieAuth: []
+        - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SafetyDocumentList'
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SafetyDocumentErrorResponse'
+          description: ''
+  /job/rest/jobs/{job_id}/jsa/generate/:
+    post:
+      operationId: generateJobJSA
+      description: Generate a new draft JSA for a job using AI
+      parameters:
+        - in: path
+          name: job_id
+          schema:
+            type: string
+            format: uuid
+          required: true
+      tags:
+        - job
+      security:
+        - cookieAuth: []
+        - {}
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SafetyDocument'
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SafetyDocumentErrorResponse'
+          description: ''
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SafetyDocumentErrorResponse'
+          description: ''
   /job/rest/jobs/{job_id}/quote/:
     get:
       operationId: job_rest_jobs_quote_retrieve
@@ -4030,6 +4102,389 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MonthEndPostResponse'
+          description: ''
+  /job/rest/safety-documents/:
+    get:
+      operationId: listSafetyDocuments
+      description: List all safety documents with optional filtering
+      tags:
+        - job
+      security:
+        - cookieAuth: []
+        - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SafetyDocumentList'
+          description: ''
+  /job/rest/safety-documents/{doc_id}/:
+    get:
+      operationId: getSafetyDocument
+      description: Retrieve a specific safety document
+      parameters:
+        - in: path
+          name: doc_id
+          schema:
+            type: string
+            format: uuid
+          required: true
+      tags:
+        - job
+      security:
+        - cookieAuth: []
+        - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SafetyDocument'
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SafetyDocumentErrorResponse'
+          description: ''
+    put:
+      operationId: updateSafetyDocument
+      description: Full update of a draft safety document
+      parameters:
+        - in: path
+          name: doc_id
+          schema:
+            type: string
+            format: uuid
+          required: true
+      tags:
+        - job
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SafetyDocumentRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/SafetyDocumentRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/SafetyDocumentRequest'
+        required: true
+      security:
+        - cookieAuth: []
+        - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SafetyDocument'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SafetyDocumentErrorResponse'
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SafetyDocumentErrorResponse'
+          description: ''
+    patch:
+      operationId: partialUpdateSafetyDocument
+      description: Partial update of a draft safety document
+      parameters:
+        - in: path
+          name: doc_id
+          schema:
+            type: string
+            format: uuid
+          required: true
+      tags:
+        - job
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedSafetyDocumentRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedSafetyDocumentRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedSafetyDocumentRequest'
+      security:
+        - cookieAuth: []
+        - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SafetyDocument'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SafetyDocumentErrorResponse'
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SafetyDocumentErrorResponse'
+          description: ''
+    delete:
+      operationId: deleteSafetyDocument
+      description: Delete a draft safety document
+      parameters:
+        - in: path
+          name: doc_id
+          schema:
+            type: string
+            format: uuid
+          required: true
+      tags:
+        - job
+      security:
+        - cookieAuth: []
+        - {}
+      responses:
+        '204':
+          description: No response body
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SafetyDocumentErrorResponse'
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SafetyDocumentErrorResponse'
+          description: ''
+  /job/rest/safety-documents/{doc_id}/finalize/:
+    post:
+      operationId: finalizeSafetyDocument
+      description: Finalize a draft safety document by generating PDF
+      parameters:
+        - in: path
+          name: doc_id
+          schema:
+            type: string
+            format: uuid
+          required: true
+      tags:
+        - job
+      security:
+        - cookieAuth: []
+        - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SafetyDocument'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SafetyDocumentErrorResponse'
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SafetyDocumentErrorResponse'
+          description: ''
+  /job/rest/safety-documents/{doc_id}/pdf/:
+    get:
+      operationId: getSafetyDocumentPDF
+      description: Download the PDF for a finalized safety document
+      parameters:
+        - in: path
+          name: doc_id
+          schema:
+            type: string
+            format: uuid
+          required: true
+      tags:
+        - job
+      security:
+        - cookieAuth: []
+        - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: string
+                format: binary
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SafetyDocumentErrorResponse'
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SafetyDocumentErrorResponse'
+          description: ''
+  /job/rest/safety-documents/{doc_id}/tasks/{task_num}/generate-controls/:
+    post:
+      operationId: generateTaskControls
+      description: Generate control measures for a task's hazards using AI
+      parameters:
+        - in: path
+          name: doc_id
+          schema:
+            type: string
+            format: uuid
+          required: true
+        - in: path
+          name: task_num
+          schema:
+            type: integer
+          required: true
+      tags:
+        - job
+      security:
+        - cookieAuth: []
+        - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  controls:
+                    type: array
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SafetyDocumentErrorResponse'
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SafetyDocumentErrorResponse'
+          description: ''
+  /job/rest/safety-documents/{doc_id}/tasks/{task_num}/generate-hazards/:
+    post:
+      operationId: generateTaskHazards
+      description: Generate hazards for a specific task using AI
+      parameters:
+        - in: path
+          name: doc_id
+          schema:
+            type: string
+            format: uuid
+          required: true
+        - in: path
+          name: task_num
+          schema:
+            type: integer
+          required: true
+      tags:
+        - job
+      security:
+        - cookieAuth: []
+        - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  hazards:
+                    type: array
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SafetyDocumentErrorResponse'
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SafetyDocumentErrorResponse'
+          description: ''
+  /job/rest/swp/:
+    get:
+      operationId: listSWPs
+      description: List all Safe Work Procedures
+      tags:
+        - job
+      security:
+        - cookieAuth: []
+        - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SafetyDocumentList'
+          description: ''
+  /job/rest/swp/generate/:
+    post:
+      operationId: generateSWP
+      description: Generate a new draft SWP using AI
+      tags:
+        - job
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SWPGenerateRequestRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/SWPGenerateRequestRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/SWPGenerateRequestRequest'
+        required: true
+      security:
+        - cookieAuth: []
+        - {}
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SafetyDocument'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SafetyDocumentErrorResponse'
+          description: ''
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SafetyDocumentErrorResponse'
           description: ''
   /job/rest/timesheet/entries/:
     get:
@@ -7103,6 +7558,31 @@ components:
         - not_cancelled
         - not_invoiced
         - not_paid
+    ControlMeasure:
+      type: object
+      description: Serializer for individual control measures within a task.
+      properties:
+        measure:
+          type: string
+          description: The control measure description
+        associated_hazard:
+          type: string
+          description: The hazard this control addresses
+      required:
+        - measure
+    ControlMeasureRequest:
+      type: object
+      description: Serializer for individual control measures within a task.
+      properties:
+        measure:
+          type: string
+          minLength: 1
+          description: The control measure description
+        associated_hazard:
+          type: string
+          description: The hazard this control addresses
+      required:
+        - measure
     CostLine:
       type: object
       description: Serializer for CostLine model - read-only with basic depth
@@ -7810,6 +8290,14 @@ components:
             next.
       required:
         - id
+    DocumentTypeEnum:
+      enum:
+        - jsa
+        - swp
+      type: string
+      description: |-
+        * `jsa` - Job Safety Analysis
+        * `swp` - Safe Work Procedure
     DraftLine:
       type: object
       description: Serializer for draft line data.
@@ -7984,6 +8472,18 @@ components:
             type: string
         error:
           type: string
+    InitialRiskRatingEnum:
+      enum:
+        - Low
+        - Moderate
+        - High
+        - Extreme
+      type: string
+      description: |-
+        * `Low` - Low
+        * `Moderate` - Moderate
+        * `High` - High
+        * `Extreme` - Extreme
     Invoice:
       type: object
       properties:
@@ -10722,6 +11222,55 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/PurchaseOrderLineUpdateRequest'
+    PatchedSafetyDocumentRequest:
+      type: object
+      description: |-
+        Main serializer for SafetyDocument model.
+
+        Used for CRUD operations on existing documents.
+      properties:
+        document_type:
+          allOf:
+            - $ref: '#/components/schemas/DocumentTypeEnum'
+          description: |-
+            Type of safety document (JSA or SWP)
+
+            * `jsa` - Job Safety Analysis
+            * `swp` - Safe Work Procedure
+        status:
+          allOf:
+            - $ref: '#/components/schemas/Status6b5Enum'
+          description: |-
+            Draft = editable, Final = PDF generated
+
+            * `draft` - Draft
+            * `final` - Final
+        title:
+          type: string
+          minLength: 1
+          description: Job name for JSA, procedure name for SWP
+          maxLength: 255
+        company_name:
+          type: string
+          minLength: 1
+          maxLength: 255
+        site_location:
+          type: string
+          description: Work site location (optional for SWPs)
+          maxLength: 500
+        description:
+          type: string
+          minLength: 1
+          description: Job description for JSA, procedure scope for SWP
+        ppe_requirements:
+          description: List of required PPE items, e.g. ["Hard hat", "Safety glasses"]
+        tasks:
+          type: array
+          items:
+            $ref: '#/components/schemas/SafetyTaskRequest'
+        additional_notes:
+          type: string
+          description: Additional safety notes or site-specific requirements
     PatchedStaffRequest:
       type: object
       description: Base serializer for Staff model with shared logic for create and
@@ -12014,6 +12563,18 @@ components:
         - job_name
         - job_number
         - sheet_id
+    RevisedRiskRatingEnum:
+      enum:
+        - Low
+        - Moderate
+        - High
+        - Extreme
+      type: string
+      description: |-
+        * `Low` - Low
+        * `Moderate` - Moderate
+        * `High` - High
+        * `Extreme` - Extreme
     RoleEnum:
       enum:
         - user
@@ -12022,6 +12583,350 @@ components:
       description: |-
         * `user` - User
         * `assistant` - Assistant
+    SWPGenerateRequestRequest:
+      type: object
+      description: Request serializer for generating a new SWP (standalone).
+      properties:
+        title:
+          type: string
+          minLength: 1
+          description: Name of the safe work procedure
+          maxLength: 255
+        description:
+          type: string
+          minLength: 1
+          description: Scope and description of the procedure
+        site_location:
+          type: string
+          description: Optional site location for the procedure
+      required:
+        - description
+        - title
+    SafetyDocument:
+      type: object
+      description: |-
+        Main serializer for SafetyDocument model.
+
+        Used for CRUD operations on existing documents.
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        document_type:
+          allOf:
+            - $ref: '#/components/schemas/DocumentTypeEnum'
+          description: |-
+            Type of safety document (JSA or SWP)
+
+            * `jsa` - Job Safety Analysis
+            * `swp` - Safe Work Procedure
+        job_id:
+          type: string
+          format: uuid
+          readOnly: true
+          nullable: true
+          description: Linked job ID (null for SWPs)
+        job_number:
+          type: string
+          readOnly: true
+          nullable: true
+          description: Linked job number (null for SWPs)
+        status:
+          allOf:
+            - $ref: '#/components/schemas/Status6b5Enum'
+          description: |-
+            Draft = editable, Final = PDF generated
+
+            * `draft` - Draft
+            * `final` - Final
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+        title:
+          type: string
+          description: Job name for JSA, procedure name for SWP
+          maxLength: 255
+        company_name:
+          type: string
+          maxLength: 255
+        site_location:
+          type: string
+          description: Work site location (optional for SWPs)
+          maxLength: 500
+        description:
+          type: string
+          description: Job description for JSA, procedure scope for SWP
+        ppe_requirements:
+          description: List of required PPE items, e.g. ["Hard hat", "Safety glasses"]
+        tasks:
+          type: array
+          items:
+            $ref: '#/components/schemas/SafetyTask'
+        additional_notes:
+          type: string
+          description: Additional safety notes or site-specific requirements
+        pdf_file_path:
+          type: string
+          readOnly: true
+          description: Relative path from DROPBOX_WORKFLOW_FOLDER to generated PDF
+        pdf_url:
+          type: string
+          nullable: true
+          description: Generate URL for PDF download if available.
+          readOnly: true
+        context_document_ids:
+          readOnly: true
+          description: UUIDs of documents used as context during generation
+      required:
+        - company_name
+        - context_document_ids
+        - created_at
+        - description
+        - document_type
+        - id
+        - job_id
+        - job_number
+        - pdf_file_path
+        - pdf_url
+        - tasks
+        - title
+        - updated_at
+    SafetyDocumentErrorResponse:
+      type: object
+      description: Serializer for error responses.
+      properties:
+        status:
+          type: string
+          default: error
+        message:
+          type: string
+      required:
+        - message
+    SafetyDocumentList:
+      type: object
+      description: |-
+        Lightweight serializer for listing safety documents.
+
+        Excludes full task details for performance.
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        document_type:
+          allOf:
+            - $ref: '#/components/schemas/DocumentTypeEnum'
+          description: |-
+            Type of safety document (JSA or SWP)
+
+            * `jsa` - Job Safety Analysis
+            * `swp` - Safe Work Procedure
+        job_number:
+          type: string
+          readOnly: true
+          nullable: true
+        status:
+          allOf:
+            - $ref: '#/components/schemas/Status6b5Enum'
+          description: |-
+            Draft = editable, Final = PDF generated
+
+            * `draft` - Draft
+            * `final` - Final
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+        title:
+          type: string
+          description: Job name for JSA, procedure name for SWP
+          maxLength: 255
+        site_location:
+          type: string
+          description: Work site location (optional for SWPs)
+          maxLength: 500
+        task_count:
+          type: integer
+          description: Get number of tasks in the document.
+          readOnly: true
+        has_pdf:
+          type: boolean
+          description: Check if document has a generated PDF.
+          readOnly: true
+      required:
+        - created_at
+        - document_type
+        - has_pdf
+        - id
+        - job_number
+        - task_count
+        - title
+        - updated_at
+    SafetyDocumentRequest:
+      type: object
+      description: |-
+        Main serializer for SafetyDocument model.
+
+        Used for CRUD operations on existing documents.
+      properties:
+        document_type:
+          allOf:
+            - $ref: '#/components/schemas/DocumentTypeEnum'
+          description: |-
+            Type of safety document (JSA or SWP)
+
+            * `jsa` - Job Safety Analysis
+            * `swp` - Safe Work Procedure
+        status:
+          allOf:
+            - $ref: '#/components/schemas/Status6b5Enum'
+          description: |-
+            Draft = editable, Final = PDF generated
+
+            * `draft` - Draft
+            * `final` - Final
+        title:
+          type: string
+          minLength: 1
+          description: Job name for JSA, procedure name for SWP
+          maxLength: 255
+        company_name:
+          type: string
+          minLength: 1
+          maxLength: 255
+        site_location:
+          type: string
+          description: Work site location (optional for SWPs)
+          maxLength: 500
+        description:
+          type: string
+          minLength: 1
+          description: Job description for JSA, procedure scope for SWP
+        ppe_requirements:
+          description: List of required PPE items, e.g. ["Hard hat", "Safety glasses"]
+        tasks:
+          type: array
+          items:
+            $ref: '#/components/schemas/SafetyTaskRequest'
+        additional_notes:
+          type: string
+          description: Additional safety notes or site-specific requirements
+      required:
+        - company_name
+        - description
+        - document_type
+        - tasks
+        - title
+    SafetyTask:
+      type: object
+      description: Serializer for individual tasks within a safety document.
+      properties:
+        step_number:
+          type: integer
+          minimum: 1
+        description:
+          type: string
+        summary:
+          type: string
+          description: 1-3 word summary of the task
+        potential_hazards:
+          type: array
+          items:
+            type: string
+          description: List of potential hazards for this task
+        initial_risk_rating:
+          allOf:
+            - $ref: '#/components/schemas/InitialRiskRatingEnum'
+          description: |-
+            Risk rating before controls are applied
+
+            * `Low` - Low
+            * `Moderate` - Moderate
+            * `High` - High
+            * `Extreme` - Extreme
+        control_measures:
+          type: array
+          items:
+            $ref: '#/components/schemas/ControlMeasure'
+          description: List of control measures to mitigate hazards
+        revised_risk_rating:
+          allOf:
+            - $ref: '#/components/schemas/RevisedRiskRatingEnum'
+          description: |-
+            Risk rating after controls are applied
+
+            * `Low` - Low
+            * `Moderate` - Moderate
+            * `High` - High
+            * `Extreme` - Extreme
+      required:
+        - control_measures
+        - description
+        - initial_risk_rating
+        - potential_hazards
+        - revised_risk_rating
+        - step_number
+    SafetyTaskRequest:
+      type: object
+      description: Serializer for individual tasks within a safety document.
+      properties:
+        step_number:
+          type: integer
+          minimum: 1
+        description:
+          type: string
+          minLength: 1
+        summary:
+          type: string
+          description: 1-3 word summary of the task
+        potential_hazards:
+          type: array
+          items:
+            type: string
+            minLength: 1
+          description: List of potential hazards for this task
+        initial_risk_rating:
+          allOf:
+            - $ref: '#/components/schemas/InitialRiskRatingEnum'
+          description: |-
+            Risk rating before controls are applied
+
+            * `Low` - Low
+            * `Moderate` - Moderate
+            * `High` - High
+            * `Extreme` - Extreme
+        control_measures:
+          type: array
+          items:
+            $ref: '#/components/schemas/ControlMeasureRequest'
+          description: List of control measures to mitigate hazards
+        revised_risk_rating:
+          allOf:
+            - $ref: '#/components/schemas/RevisedRiskRatingEnum'
+          description: |-
+            Risk rating after controls are applied
+
+            * `Low` - Low
+            * `Moderate` - Moderate
+            * `High` - High
+            * `Extreme` - Extreme
+      required:
+        - control_measures
+        - description
+        - initial_risk_rating
+        - potential_hazards
+        - revised_risk_rating
+        - step_number
     SourceEnum:
       enum:
         - purchase_order
@@ -12755,6 +13660,14 @@ components:
         * `DELETED` - Deleted
         * `VOIDED` - Voided
         * `PAID` - Paid
+    Status6b5Enum:
+      enum:
+        - draft
+        - final
+      type: string
+      description: |-
+        * `draft` - Draft
+        * `final` - Final
     Status7aeEnum:
       enum:
         - DRAFT

--- a/src/components/AdvancedSearchDialog.vue
+++ b/src/components/AdvancedSearchDialog.vue
@@ -7,6 +7,27 @@
       </DialogHeader>
 
       <div class="space-y-4">
+        <!-- Universal Search -->
+        <div class="bg-blue-50 border border-blue-200 rounded-lg p-4">
+          <label class="block text-sm font-medium text-blue-800 mb-1">
+            Search All Fields
+          </label>
+          <input
+            v-model="localFilters.q"
+            type="text"
+            class="w-full px-3 py-2 border border-blue-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+            placeholder="Search job number, name, description, or client..."
+          />
+          <p class="mt-1 text-xs text-blue-600">
+            Searches across job number, name, description, and client name
+          </p>
+        </div>
+
+        <!-- Individual Field Filters -->
+        <div class="border-t pt-4">
+          <p class="text-xs text-gray-500 mb-3">Or filter by specific fields:</p>
+        </div>
+
         <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
           <div>
             <label class="block text-sm font-medium text-gray-700 mb-1">Job Number</label>

--- a/src/constants/advanced-filters.ts
+++ b/src/constants/advanced-filters.ts
@@ -11,6 +11,7 @@ import { z } from 'zod'
  * Schema for advanced search filters
  */
 export const AdvancedFiltersSchema = z.object({
+  q: z.string().optional().default(''), // Universal search across multiple fields
   job_number: z.string().optional().default(''),
   name: z.string().optional().default(''),
   description: z.string().optional().default(''),
@@ -31,6 +32,7 @@ export type AdvancedFilters = z.infer<typeof AdvancedFiltersSchema>
  * Default empty filter state
  */
 export const DEFAULT_ADVANCED_FILTERS: AdvancedFilters = {
+  q: '',
   job_number: '',
   name: '',
   description: '',


### PR DESCRIPTION
## Summary
- Add `q` parameter to search across job number, name, description, and client name with OR logic
- Add "Search All Fields" input to Advanced Search dialog UI  
- Simplify quick search to use universal `q` parameter
- Fix loading state: columns now show loading spinner during advanced search

## Problem
Searching for "Sistema" (client name) didn't find jobs because the frontend only searched the `name` field, not `client_name`.

## Solution
Backend now supports `?q=Sistema` which searches across multiple fields with OR logic. Frontend updated to use this for both quick search and advanced search.

## Changes
| File | Change |
|------|--------|
| `schema.yml` / `api.ts` | Backend added `q` parameter (regenerated) |
| `src/constants/advanced-filters.ts` | Added `q` field to schema |
| `src/components/AdvancedSearchDialog.vue` | Added "Search All Fields" UI box |
| `src/composables/useOptimizedKanban.ts` | Use `q` for search + fix loading state |

## Test plan
- [x] Quick search: type "Sistema" → finds jobs with Sistema client
- [x] Quick search: type "96403" → finds job 96403
- [x] Advanced search: type "Sistema" in "Search All Fields" + tick "Paid" → finds paid Sistema jobs
- [x] Columns show loading spinner while search is in progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)