### PR TITLE
feat: populate training manual and wire up deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,19 @@ Source files live in the `src/` directory:
 - **types/** – TypeScript interfaces
 - **views/** – Page‑level Vue components
 
+## Training Manual
+
+The staff training manual is built with VitePress and served at `/manual/` in production.
+
+```bash
+npm run manual:dev       # Dev server on port 5174 (hot-reload)
+npm run manual:build     # Production build to dist-manual/
+npm run manual:pdf       # Export as PDF
+npm run manual:screenshots  # Capture screenshots (needs running app + .env credentials)
+```
+
+Markdown source lives in `manual/`. Edit pages there and preview with `manual:dev`.
+
 ## Additional Documentation
 
 See `docs/overview.md` for a newcomer‑oriented explanation of the codebase.

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -21,6 +21,7 @@ export default defineConfigWithVueTs(
     '**/dist/**',
     '**/dist-ssr/**',
     '**/dist-manual/**',
+    'manual/.vitepress/cache/**',
     '**/coverage/**',
     '**/scripts/**',
     '**/playwright-report/**',

--- a/manual/.vitepress/config.ts
+++ b/manual/.vitepress/config.ts
@@ -4,6 +4,9 @@ export default defineConfig({
   title: 'Jobs Manager Training Manual',
   description: 'How to do your job - a cookbook for staff',
 
+  // Served at /manual/ alongside the main app
+  base: '/manual/',
+
   // Output directory (relative to manual/ folder)
   outDir: '../dist-manual',
 
@@ -14,6 +17,13 @@ export default defineConfig({
       {
         text: 'Customer Contact',
         items: [{ text: 'New Customer Call', link: '/enquiries/new-customer-call' }],
+      },
+      {
+        text: 'Jobs',
+        items: [
+          { text: 'Understanding Job Finances', link: '/jobs/understanding-job-finances' },
+          { text: 'Attach Files to a Job', link: '/jobs/attach-files' },
+        ],
       },
       {
         text: 'Quoting',
@@ -35,16 +45,24 @@ export default defineConfig({
         items: [{ text: 'End of Day Entry', link: '/timesheets/end-of-day-entry' }],
       },
       {
+        text: 'Purchasing',
+        items: [{ text: 'Create a Purchase Order', link: '/purchasing/create-purchase-order' }],
+      },
+      {
         text: 'Invoicing',
         items: [{ text: 'Invoice a Job', link: '/invoicing/invoice-a-job' }],
       },
       {
-        text: 'Weekly Procedures',
+        text: 'Weekly & Monthly Procedures',
         items: [{ text: 'Weekly Checklist', link: '/end-of-week/weekly-checklist' }],
       },
       {
-        text: 'Management',
-        items: [{ text: 'Run Reports', link: '/management/run-reports' }],
+        text: 'Management & Admin',
+        items: [
+          { text: 'Run Reports', link: '/management/run-reports' },
+          { text: 'Run Payroll', link: '/admin/run-payroll' },
+          { text: 'Manage Staff', link: '/admin/manage-staff' },
+        ],
       },
     ],
 

--- a/manual/admin/manage-staff.md
+++ b/manual/admin/manage-staff.md
@@ -1,0 +1,74 @@
+---
+title: Manage Staff
+---
+
+# Manage Staff
+
+> **When to use:** You need to add a new team member, update someone's details, or change their permissions.
+
+## What You'll Need
+
+- [ ] Superuser access (only superusers can manage staff)
+- [ ] The new person's details (name, email, wage rate)
+
+## Steps
+
+### 1. Open Staff Management
+
+Navigate to **Admin > Staff** (you need to be a superuser to see this).
+
+<!-- PLACEHOLDER: Screenshot showing the Staff Management page with the staff table -->
+
+You'll see a table listing all staff members with their name, role (Office Staff / SuperUser), last login, and date joined.
+
+### 2. Add a new staff member
+
+Click **New Staff** to open the staff form. It has three tabs:
+
+#### Personal Info
+
+<!-- PLACEHOLDER: Screenshot showing the Personal Info tab of the staff form -->
+
+- **First Name** and **Last Name** -- as you'd expect.
+- **Preferred Name** -- what they go by day-to-day (optional).
+- **Email** -- their login email. Must be unique.
+- **Password** -- at least 8 characters. They can change it later.
+- **Base Wage Rate** -- their hourly wage in NZD. This is used for job costing calculations.
+- **Xero User ID** -- links them to their Xero profile for payroll (optional).
+- **Profile Icon** -- click the avatar to upload a photo.
+
+#### Working Hours
+
+<!-- PLACEHOLDER: Screenshot showing the Working Hours tab -->
+
+Set the scheduled hours for each day of the week (Monday through Sunday). Enter in quarter-hour increments (0.25, 0.5, etc.). These are used in the timesheet summary to show whether a full day has been entered.
+
+#### Permissions
+
+- **Is Office Staff** -- tick this for office-based staff. It controls which navbar items they see (office staff see everything; non-office staff see a simplified view focused on their own time entry).
+- **Is SuperUser** -- tick this for people who need admin access (staff management, system settings, etc.).
+
+### 3. Edit an existing staff member
+
+Click the **Edit** button next to any staff member in the table. The same form opens, pre-filled with their current details. You can change anything except their email.
+
+### 4. Remove a staff member
+
+Click the **Delete** button next to their name. You'll be asked to confirm before anything happens.
+
+## What Happens Next
+
+- New staff members can log in immediately with their email and password
+- Their wage rate feeds into job costing whenever they enter time
+- Their scheduled hours appear in the timesheet summary for checking daily totals
+- If linked to Xero, their payroll data can be reconciled using the [Payroll report](/admin/run-payroll)
+
+## Tips
+
+::: tip
+Set up working hours accurately -- they're used to check whether a full day of time has been entered. If someone works 7.5 hours and the system expects 8, it'll flag every day as incomplete.
+:::
+
+::: warning
+Be careful with the SuperUser permission. SuperUsers can see everything and manage all settings. Only give this to people who genuinely need it.
+:::

--- a/manual/admin/run-payroll.md
+++ b/manual/admin/run-payroll.md
@@ -1,0 +1,84 @@
+---
+title: Run Payroll
+---
+
+# Run Payroll
+
+> **When to use:** You need to check that what Xero paid in payroll matches what Jobs Manager calculated from timesheets.
+
+## What You'll Need
+
+- [ ] Access to the Payroll Reconciliation report
+- [ ] Payroll already run in Xero for the period you're checking
+
+## Steps
+
+### 1. Open the Payroll Reconciliation report
+
+Navigate to **Reports > Reconciliation > Payroll (Xero)**.
+
+<!-- PLACEHOLDER: Screenshot showing the Payroll Reconciliation page with summary cards and heatmap -->
+
+### 2. Set the date range
+
+Pick your start and end dates, or use one of the quick presets:
+
+- **This FY** -- current financial year
+- **Last FY** -- previous financial year
+- **Last 30 Weeks** -- a rolling window
+
+The dates snap to week boundaries automatically -- you don't need to worry about picking exact Monday-to-Sunday ranges.
+
+### 3. Read the summary cards
+
+At the top you'll see three cards:
+
+- **Xero Total** -- What Xero says was paid in gross payroll
+- **JM Total** -- What Jobs Manager calculated from timesheets and wage rates
+- **Difference** -- The gap between the two, shown in dollars and as a percentage
+
+If the difference is small (a few dollars), everything's fine. If it's significant, something needs investigating.
+
+### 4. Use the heatmap to find problems
+
+<!-- PLACEHOLDER: Screenshot showing the payroll heatmap grid with colour-coded cells -->
+
+The heatmap grid shows every week (rows) by every staff member (columns). Each cell is colour-coded:
+
+- **Green** -- Difference is less than $1. Xero and JM agree.
+- **Blue shades** -- Xero paid more than JM calculated (overpayment or a Xero adjustment).
+- **Red shades** -- Xero paid less than JM calculated (underpayment or missing hours in Xero). Darker red means a bigger gap.
+
+### 5. Drill into the details
+
+Hover over any cell to see the full breakdown:
+
+- **Xero**: Hours worked and gross amount paid
+- **JM**: Hours entered and calculated cost
+- **Gap**: The dollar difference
+- **Hours impact**: How much of the gap comes from different hours
+- **Rate impact**: How much comes from different wage rates
+
+This tells you whether the problem is missing hours (someone didn't enter all their time) or a rate mismatch (the wage rate in JM doesn't match Xero).
+
+### 6. Export if needed
+
+Click **Export CSV** to download the data for further analysis in Excel, or to share with your accountant.
+
+## What Happens Next
+
+- If everything matches, you're done -- payroll is reconciled for that period
+- If there are discrepancies, investigate the red/blue cells:
+  - **Missing hours**: Check timesheets for that staff member in that week
+  - **Rate mismatch**: Compare the wage rate in [Staff Management](/admin/manage-staff) with Xero
+  - **Xero adjustments**: Check if Xero has manual adjustments (leave, bonuses, etc.) that JM wouldn't know about
+
+## Tips
+
+::: tip
+Run this report weekly right after payroll. Catching a discrepancy the same week is easy to fix. Finding it three months later is a headache.
+:::
+
+::: warning
+The report compares gross figures. If Xero has manual adjustments (sick leave, bonuses, deductions), they'll show as differences here. That's expected -- just make sure you can account for them.
+:::

--- a/manual/end-of-week/weekly-checklist.md
+++ b/manual/end-of-week/weekly-checklist.md
@@ -4,27 +4,58 @@ title: Weekly Checklist
 
 # Weekly Checklist
 
-> **When to use:** End of the week admin procedures.
+> **When to use:** End of the week admin procedures -- making sure nothing's fallen through the cracks.
 
 ## What You'll Need
 
-- [ ] Access to reports
-- [ ] Time to review outstanding items
+- [ ] Access to reports and the Kanban board
+- [ ] 30-60 minutes of uninterrupted time
 
 ## Weekly Tasks
 
 ### Review Outstanding Quotes
 
-[TODO: How to find quotes that haven't been responded to]
+Check for any quotes that have been sent but not responded to. Open the Kanban board and look at jobs sitting in the "Quoted" column. If anything's been there more than a week, follow up with the customer.
+
+<!-- PLACEHOLDER: Screenshot showing the Kanban board with jobs in the Quoted column -->
 
 ### Check Unbilled Work
 
-[TODO: Jobs that are complete but not invoiced]
+Look for jobs that are complete but haven't been invoiced yet. These are jobs sitting in the "Complete" column on the Kanban board, or you can use the Job Aging report under Reports > Management to find them.
+
+Every week a completed job sits uninvoiced is a week you're not getting paid for work you've already done.
 
 ### Timesheet Review
 
-[TODO: Any missing or incomplete timesheets]
+Go through each staff member's timesheets for the week using the Daily Overview. Check that:
+
+- Everyone has entered a full day's hours for each day they worked
+- The summary shows hours that match their scheduled hours
+- There aren't unusual patterns (lots of non-billable time, missing days, etc.)
+
+<!-- PLACEHOLDER: Screenshot showing the timesheet daily overview with staff hours -->
+
+If someone's hours don't add up, check with them before the week is out. It's much easier to fix on Friday than to reconstruct the following week.
+
+### Month End (Monthly)
+
+At the end of each month, run the month-end process under Admin. This is mostly for shop jobs -- it resets the hours each month so you start fresh.
+
+<!-- PLACEHOLDER: Screenshot showing the Admin month-end page -->
 
 ### Follow-up Actions
 
-[TODO: Other weekly admin tasks]
+- Chase any overdue customer payments (check in Xero)
+- Review the [KPI Report](/management/run-reports) for the week -- are we tracking to target?
+- Update job statuses on the Kanban board for anything that's moved along during the week
+- Flag any jobs that are going over budget so they can be discussed
+
+## Tips
+
+::: tip
+Make this a recurring calendar event every Friday afternoon. It takes less time than you think and prevents small problems from becoming big ones.
+:::
+
+::: warning
+Don't skip the timesheet review. Missing or inaccurate timesheets mean inaccurate job costing, which means you don't know if you're making or losing money.
+:::

--- a/manual/enquiries/new-customer-call.md
+++ b/manual/enquiries/new-customer-call.md
@@ -26,27 +26,43 @@ If they're new, you'll create a record as part of the next step.
 
 <!-- PLACEHOLDER: Screenshot of create job form -->
 
-[TODO: Explain what information to capture and why]
+Click **Create Job** in the navbar. Fill in the basic details:
+
+- **Job Number** -- This is auto-generated, just like our old paper job numbers.
+- **Job Name** -- An internal nickname for the job. This is handy for searching later, so make it something memorable (e.g. "Smith fence repair" rather than "Job for Mr Smith").
+- **Client** -- This must match the entry in Xero. Start typing and it'll autocomplete. If the client doesn't exist, you can create one from here.
+- **Job Description** -- This gets printed on invoices and quotes, so write it for the customer's eyes. Keep it professional and clear.
 
 ### 3. Record the key details
 
-[TODO: What fields matter and what can wait]
+<!-- PLACEHOLDER: Screenshot showing a populated job details form -->
+
+The other fields on the job form:
+
+- **Contact Name** and **Phone Number** -- Who to call about this job.
+- **Order Number** -- The client's reference number, if they have one.
+- **Job Notes** -- Internal notes that only we see. Use this for anything relevant -- site access codes, special instructions, who you spoke to on the phone.
+
+Don't worry about filling in everything right now. The critical fields are the client, job name, and a description. Everything else can be added later as you learn more.
 
 ### 4. Set next steps
 
-[TODO: What happens after the call - site visit? Quote over phone?]
+Once you've saved the job, think about what happens next. Does someone need to go out for a site visit? Can you quote over the phone? Is it a straightforward T&M job that just needs scheduling?
+
+If you know, update the job status on the Kanban board to reflect where it's at. If not, leave it in the first column and it'll get picked up in the normal workflow.
 
 ## What Happens Next
 
-- Job appears on the Kanban board in "New Enquiries" column
-- [TODO: Who picks it up? What's the SLA?]
+- Job appears on the Kanban board where everyone can see it
+- Someone picks it up to assess and price -- see [Assess & Price a Job](/quoting/assess-and-price)
+- The job number is the reference for everything from here on out
 
 ## Tips
 
 ::: tip
-[TODO: Business tips - e.g., "Always confirm the site address, it's often different from their home"]
+Always confirm the site address -- it's often different from the customer's postal or billing address. Getting this wrong wastes everyone's time.
 :::
 
 ::: warning
-[TODO: Common mistakes - e.g., "Don't promise a quote time without checking the schedule"]
+Don't promise a quote timeframe without checking the schedule first. Better to say "we'll get back to you" than to commit to something you can't deliver.
 :::

--- a/manual/fieldwork/complete-a-job.md
+++ b/manual/fieldwork/complete-a-job.md
@@ -4,18 +4,43 @@ title: Complete a Job On-Site
 
 # Complete a Job On-Site
 
-> **When to use:** You're on-site doing the work and need to record progress/completion.
+> **When to use:** You're on-site, the work is done, and you need to mark the job as complete.
 
 ## What You'll Need
 
-- [ ] Access to the job details
-- [ ] Any required sign-off from customer
+- [ ] Access to Jobs Manager (phone or tablet is fine)
+- [ ] Any required sign-off or photos from the customer
 
 ## Steps
 
-[TODO: Document what field staff do to mark work complete]
+### 1. Record your time
+
+Make sure all your hours for this job are entered in the timesheets. If you haven't done it during the day, do it now while the details are fresh -- see [End of Day Entry](/timesheets/end-of-day-entry).
+
+### 2. Note any materials used
+
+If you used materials on-site that haven't been recorded yet, make a note. These need to be entered into the Reality section of the job so the costs are accurate.
+
+### 3. Take photos (if needed)
+
+If there's anything worth documenting -- the finished work, any issues found, before/after shots -- attach them to the job. Files added to a job automatically sync to Dropbox as well. See [Attach Files to a Job](/jobs/attach-files).
+
+### 4. Update the job status
+
+Move the job to "Complete" on the Kanban board (or ask office staff to do it if you don't have access). This signals to the office that the work is done and the job is ready for invoicing.
 
 ## What Happens Next
 
-- Job moves to "Ready to Invoice" (or similar)
-- Office staff can now prepare the invoice
+- Office staff see the job in the "Complete" column on the Kanban board
+- They'll review the timesheets and materials, then [invoice the job](/invoicing/invoice-a-job)
+- The job's actual costs feed into the KPI reports automatically
+
+## Tips
+
+::: tip
+Take photos of finished work, especially for larger jobs. They're useful for resolving disputes and for showing prospective customers what you've done.
+:::
+
+::: warning
+Don't mark a job as complete until all your time is entered. Once it moves to invoicing, missing hours mean you either don't get paid for them or someone has to go back and fix it.
+:::

--- a/manual/index.md
+++ b/manual/index.md
@@ -18,17 +18,28 @@ Pick the task you need to do:
 - [Assess & Price a Job](/quoting/assess-and-price) - Working out what to charge
 - [Send a Quote](/quoting/send-quote) - Getting the quote to the customer
 
+### Understanding Jobs
+
+- [Understanding Job Finances](/jobs/understanding-job-finances) - How estimates, quotes, and reality fit together
+- [Attach Files to a Job](/jobs/attach-files) - Drawings, photos, and documents
+
 ### Getting Work Done
 
 - [Schedule a Job](/scheduling/schedule-a-job) - Assigning work to staff
 - [Complete a Job On-Site](/fieldwork/complete-a-job) - What field staff do
 - [End of Day Entry](/timesheets/end-of-day-entry) - Recording your time
 
+### Purchasing
+
+- [Create a Purchase Order](/purchasing/create-purchase-order) - Ordering materials from suppliers
+
 ### Billing & Admin
 
 - [Invoice a Job](/invoicing/invoice-a-job) - Billing the customer
 - [Weekly Checklist](/end-of-week/weekly-checklist) - End of week procedures
 - [Run Reports](/management/run-reports) - Getting insights
+- [Run Payroll](/admin/run-payroll) - Reconciling timesheets with Xero payroll
+- [Manage Staff](/admin/manage-staff) - Adding and editing team members
 
 ---
 

--- a/manual/invoicing/invoice-a-job.md
+++ b/manual/invoicing/invoice-a-job.md
@@ -4,18 +4,59 @@ title: Invoice a Job
 
 # Invoice a Job
 
-> **When to use:** Work is complete and you need to bill the customer.
+> **When to use:** The work is done, time and materials are recorded, and it's time to bill the customer.
 
 ## What You'll Need
 
-- [ ] Completed job with all time/materials recorded
-- [ ] Customer billing details
+- [ ] A completed job with all timesheet entries recorded
+- [ ] Materials entered in the Reality section (if applicable)
+- [ ] Customer billing details in the system
 
 ## Steps
 
-[TODO: Document the invoicing process]
+### 1. Check the Reality section
+
+<!-- PLACEHOLDER: Screenshot showing the Reality/Actual tab on a job with populated data -->
+
+Before you invoice, open the job and look at the Reality section. This shows the real cost and revenue of the job -- what actually happened versus what you estimated.
+
+The timesheets section of the app automatically populates the time entries here. If staff have been entering their time correctly, the labour lines should already be filled in. Materials you'll need to enter directly into the Reality section for now.
+
+### 2. Compare estimate to reality
+
+<!-- PLACEHOLDER: Screenshot showing the Revenue and Costs summary tables -->
+
+The system keeps track of the totals for you. Check the Revenue vs Costs summary at the bottom of the job. You'll see columns for Estimate, Quote, and Reality side by side.
+
+Key things to look for:
+
+- **Revenue higher than cost** = the job made a profit
+- **Cost higher than revenue** = the job lost money -- investigate before invoicing
+- **Big gap between estimate and reality** = something went differently than planned
+
+### 3. Create the invoice
+
+<!-- PLACEHOLDER: Screenshot showing the invoice creation process -->
+
+Once you're satisfied that the numbers are right, create the invoice. This sends the billing information through to Xero where the actual invoice is generated and sent to the customer.
+
+### 4. Verify in Xero
+
+The invoice should appear in Xero shortly after creation. Check that the amounts match and that the customer details are correct.
 
 ## What Happens Next
 
-- Invoice sent to customer
-- [TODO: Integration with Xero?]
+- The invoice is created in Xero and sent to the customer
+- The job status updates to reflect that it's been invoiced
+- Payment tracking happens in Xero from this point
+- The job's profitability is now final and will show in the KPI reports
+
+## Tips
+
+::: tip
+Always check the Reality section before invoicing. If timesheets are missing or materials haven't been recorded, your invoice won't reflect the actual work done -- and you'll either undercharge the customer or have inaccurate job costing.
+:::
+
+::: warning
+If the Reality section shows the job lost money, don't just invoice and move on. Flag it so the team can learn from it. Was the estimate too low? Did the scope change? Understanding why helps prevent the same thing happening next time.
+:::

--- a/manual/jobs/attach-files.md
+++ b/manual/jobs/attach-files.md
@@ -1,0 +1,50 @@
+---
+title: Attach Files to a Job
+---
+
+# Attach Files to a Job
+
+> **When to use:** You need to add drawings, photos, documents, or any other files to a job.
+
+## What You'll Need
+
+- [ ] The file(s) you want to attach (drawings, photos, PDFs, etc.)
+- [ ] The job open in Jobs Manager
+
+## Steps
+
+### 1. Open the job and go to the Files section
+
+Navigate to the job and find the Attached Files area.
+
+<!-- PLACEHOLDER: Screenshot showing the Files/Attachments section on a job -->
+
+### 2. Upload your files
+
+Drag files into the upload area, or click to browse and select them. You can upload multiple files at once.
+
+### 3. Verify the upload
+
+Your files will appear in the attachments list. They're available immediately to anyone viewing the job.
+
+## Dropbox Sync
+
+Any files you add to a job will immediately turn up in Dropbox as well. This is particularly helpful for the laser cutter -- upload a drawing to the job and it's available on the workshop machine straight away.
+
+The same applies in reverse. Any files you add to the job's Dropbox folder will appear in Jobs Manager. So if it's easier to drop something into Dropbox from your phone or desktop, that works too.
+
+## What Happens Next
+
+- Files are attached to the job and visible to all staff
+- Files sync to Dropbox automatically (both directions)
+- They stay with the job as a permanent record -- useful for reference on repeat customers or warranty queries
+
+## Tips
+
+::: tip
+Always attach drawings to the job rather than emailing them around. That way they're archived and anyone can find them later without hunting through their inbox.
+:::
+
+::: tip
+Take before/after photos on bigger jobs and attach them. They're invaluable for resolving disputes and for showing prospective customers your work.
+:::

--- a/manual/jobs/understanding-job-finances.md
+++ b/manual/jobs/understanding-job-finances.md
@@ -1,0 +1,95 @@
+---
+title: Understanding Job Finances
+---
+
+# Understanding Job Finances
+
+> **When to use:** You want to understand how the money works on a job -- what the three financial stages mean and how they fit together.
+
+This isn't a step-by-step task. It's background knowledge that makes everything else make sense.
+
+## The Three-Part Structure
+
+From a commercial perspective, every job is divided into three parts:
+
+- **Time** -- Labour hours and wage/charge rates
+- **Materials** -- Physical goods, supplies, stock items
+- **Adjustments** -- Everything else: call-out fees, travel, discounts, write-offs
+
+You'll see this three-part breakdown everywhere in the system -- estimates, quotes, reality, and reports.
+
+## The Three Financial Stages
+
+Each job goes through three financial stages. Think of them as three different views of the same job:
+
+### Estimate (What we think it'll cost)
+
+<!-- PLACEHOLDER: Screenshot showing the Estimate tab on a job -->
+
+The estimate is your internal "finger in the air" -- what you think the job will cost us and what we should charge. It has time, materials, and adjustments sections, each with as many lines as you need.
+
+Every job should have an estimate. Even a rough one is better than none.
+
+### Quote (What we tell the customer)
+
+<!-- PLACEHOLDER: Screenshot showing the Quote tab on a job -->
+
+The quote is the customer-facing version. Not every job needs a quote -- T&M (time and materials) jobs where you bill as you go don't need one. But if the customer wants a price upfront, this is where it lives.
+
+The **Copy Estimate to Quote** button gives you a starting point. From there you can adjust -- add contingency, simplify the breakdown, reduce the price to win the work.
+
+Remember: all jobs have an estimate, while only some have a quote.
+
+### Reality (What actually happened)
+
+<!-- PLACEHOLDER: Screenshot showing the Reality/Actual tab with populated data -->
+
+The Reality section shows the real cost and revenue of the job. If revenue is higher than cost, the job made a profit.
+
+- **Time entries** are populated automatically from timesheets. When staff enter time against a job, it shows up here.
+- **Materials** need to be entered directly into the Reality section for now.
+- **Adjustments** are added manually as needed.
+
+## The Revenue vs Costs Summary
+
+<!-- PLACEHOLDER: Screenshot showing the Revenue and Costs summary tables at the bottom of a job -->
+
+At the bottom of the job you'll see summary tables that put it all together:
+
+**Revenue** shows what the customer is being charged:
+
+| Category               | Estimate | Quote  | Reality |
+| ---------------------- | -------- | ------ | ------- |
+| Total Time             | $X       | $X     | $X      |
+| Total Materials        | $X       | $X     | $X      |
+| Total Adjustments      | $X       | $X     | $X      |
+| **Total Project Cost** | **$X**   | **$X** | **$X**  |
+
+**Costs** shows what it costs us:
+
+| Category               | Estimate | Quote  | Reality |
+| ---------------------- | -------- | ------ | ------- |
+| Total Time             | $X       | $X     | $X      |
+| Total Materials        | $X       | $X     | $X      |
+| Total Adjustments      | $X       | $X     | $X      |
+| **Total Project Cost** | **$X**   | **$X** | **$X**  |
+
+The difference between Revenue and Costs is your profit. You can see at a glance whether the job is on track, over budget, or better than expected.
+
+## How It All Connects
+
+1. You [create a job](/enquiries/new-customer-call) and fill in the **Estimate**
+2. If the customer needs a price, you populate the **Quote** and [send it](/quoting/send-quote)
+3. Staff do the work and enter time -- the **Reality** section fills up automatically
+4. When the job is done, you compare Reality to Estimate to see how you went
+5. You [invoice the job](/invoicing/invoice-a-job) and it feeds into the [KPI reports](/management/run-reports)
+
+## Tips
+
+::: tip
+Get in the habit of checking the Revenue vs Costs summary before invoicing. A quick glance tells you if the job made money or not -- and if not, why not.
+:::
+
+::: warning
+Don't confuse the Estimate with the Quote. The Estimate is for us (what we think it costs). The Quote is for the customer (what we're charging them). They can be different -- and often should be.
+:::

--- a/manual/management/run-reports.md
+++ b/manual/management/run-reports.md
@@ -4,18 +4,109 @@ title: Run Reports
 
 # Run Reports
 
-> **When to use:** You need insights on jobs, staff, revenue, etc.
+> **When to use:** You want to know how the business is tracking -- profitability, job progress, staff output, or anything else that needs a number behind it.
+
+## What You'll Need
+
+- [ ] Access to Jobs Manager (you need to be logged in)
+- [ ] A rough idea of the date range you're interested in
 
 ## Available Reports
 
-[TODO: List the key reports and what they show]
+All reports live under the **Reports** menu in the navbar. They're grouped into categories:
+
+| Category           | Reports                                                                                    | What they tell you                        |
+| ------------------ | ------------------------------------------------------------------------------------------ | ----------------------------------------- |
+| **CRM**            | Clients                                                                                    | Customer list and contact details         |
+| **Management**     | Job Aging, Job Movement, Job Profitability, KPI Reports, Sales Forecast, Staff Performance | How the business is performing day-to-day |
+| **Reconciliation** | Payroll (Xero), Profit & Loss (Xero)                                                       | Whether our books line up with Xero       |
+| **Data Quality**   | Archived Jobs Validation                                                                   | Finds problems in archived job data       |
+
+Most of the time you'll be living in the **Management** reports, especially KPI Reports and Job Profitability.
 
 ## Steps
 
-[TODO: How to run a report, filter by date range, export, etc.]
+### 1. Open a report
+
+Click **Reports** in the top navbar, pick a category, then pick the report you want.
+
+<!-- PLACEHOLDER: Screenshot showing the Reports dropdown menu with categories expanded -->
+
+### 2. Set your date range
+
+Most reports let you pick a month and year. Some have a **Today** button to jump back to the current period.
+
+<!-- PLACEHOLDER: Screenshot showing the month/year selector on the KPI page -->
+
+### 3. Read the data
+
+Each report is laid out differently, but they all load automatically once you pick your dates. No need to click a "Run" button -- just change the month and the data refreshes.
+
+### 4. Export (if needed)
+
+Reports that support it have an **Export** button in the top-right corner. This gives you a download you can open in Excel or share with your accountant.
+
+## The KPI Report (In Depth)
+
+The KPI report is the one you'll probably use the most. It tells you approximately how much profit the business made in a day or a month.
+
+This is based on **when the time or parts are added to the job**, not on when the job is invoiced. If someone adds four hours on a job today, it counts for today -- not whatever day the job happens to be invoiced.
+
+### Summary cards
+
+At the top of the page you'll see four cards:
+
+<!-- PLACEHOLDER: Screenshot showing the four KPI summary cards (Labour, Materials, Adjustments, Profit) -->
+
+- **Labour** -- Billable hours billed to clients, total wages paid, and the average daily billable hours as a percentage. This is the big one. If the team billed 38 hours against a 45-hour target, it'll show as amber. Hit the target and it goes green.
+- **Materials** -- Material profit, revenue, cost, and margin percentage.
+- **Adjustments** -- Same breakdown as materials but for adjustments (discounts, write-offs, extras).
+- **Profit** -- The bottom line: net profit, total revenue, gross profit, and net margin percentage.
+
+You can click any card to see a more detailed breakdown.
+
+### Calendar heatmap
+
+Below the cards is a calendar view of the month. Each day is colour-coded:
+
+- **Green** = good day (hit targets)
+- **Amber** = okay, but below target
+- **Red** = bad day (lost money or well below target)
+
+<!-- PLACEHOLDER: Screenshot showing the KPI calendar heatmap with green, amber, and red days -->
+
+Each day shows the hours worked and the profit or loss for that day. You can see at a glance which days went well and which didn't.
+
+### Daily detail (click a day)
+
+Click on any day in the calendar and a detail panel pops up showing:
+
+<!-- PLACEHOLDER: Screenshot showing the KPI day detail modal with revenue, cost, and profit tables -->
+
+- **Revenue table** -- Labour Revenue, Material Revenue, Adjustment Revenue, Total Revenue
+- **Cost table** -- Labour Cost, Material Cost, Adjustment Cost, Total Cost
+- **Gross Profit Breakdown** -- Labour Profit, Material Profit, Adjustment Profit, Total Gross Profit
+- **Profit by Job** -- A table listing every job that had activity that day (Job #, Labour, Materials, Adjustments, Total). Profitable jobs show in green. Jobs that lost money show in red/pink.
+
+The negative numbers you'll sometimes see for time on jobs are internal jobs -- things like shop maintenance, training, or admin. Those are expected.
+
+## What Happens Next
+
+- Reports update in real time as staff enter time, materials, and adjustments throughout the day
+- Use the data to spot problems early -- a run of red days means something needs attention
+- Share exports with your accountant or use them in team meetings
+- The Reconciliation reports (Payroll and P&L) are for checking that Jobs Manager lines up with what's in Xero
 
 ## Tips
 
 ::: tip
-[TODO: Which reports are most useful for what purpose]
+The KPI report is most useful at the end of each day. Check it before you leave to see how the team went. A quick glance at the calendar heatmap tells you everything you need to know.
+:::
+
+::: tip
+If a day is showing red, click into it and look at the Profit by Job table. The red rows will tell you exactly which jobs lost money and why.
+:::
+
+::: warning
+The KPI numbers are based on when work is recorded, not when it's invoiced. Don't compare KPI figures directly to your Xero invoicing for the same month -- they measure different things. Use the Reconciliation reports for that.
 :::

--- a/manual/purchasing/create-purchase-order.md
+++ b/manual/purchasing/create-purchase-order.md
@@ -1,0 +1,86 @@
+---
+title: Create a Purchase Order
+---
+
+# Create a Purchase Order
+
+> **When to use:** You need to order materials or supplies from a supplier for a job.
+
+## What You'll Need
+
+- [ ] Supplier details (must be set up in the system)
+- [ ] List of items to order (descriptions, quantities, costs)
+- [ ] The job number to allocate the purchase against
+
+## Steps
+
+### 1. Create a new PO
+
+Navigate to **Purchases > Purchase Orders** in the navbar, then click **New Purchase Order**.
+
+<!-- PLACEHOLDER: Screenshot showing the Purchase Orders list page -->
+
+Fill in the basic details:
+
+- **Supplier** -- Select from the dropdown. Must match an existing supplier.
+- **Reference** -- Your internal reference or the supplier's quote number.
+- **Expected Delivery Date** -- When you expect the goods to arrive.
+- **Pickup Address** -- If applicable, where the goods will be picked up from.
+
+Click **Save** to create the PO and open it for editing.
+
+### 2. Add line items
+
+<!-- PLACEHOLDER: Screenshot showing the PO line items table with example entries -->
+
+In the line items table, add each item you're ordering:
+
+| Field           | What it means                            |
+| --------------- | ---------------------------------------- |
+| **Item Code**   | The supplier's product code              |
+| **Description** | What you're ordering                     |
+| **Quantity**    | How many                                 |
+| **Unit Cost**   | Price per unit                           |
+| **Price TBC**   | Tick this if you don't know the cost yet |
+| **Job**         | Which job this item is for               |
+
+You can assign different line items to different jobs on the same PO.
+
+### 3. Review and submit
+
+Check the totals and make sure everything looks right. When you're ready, change the status from **Draft** to **Submitted**.
+
+<!-- PLACEHOLDER: Screenshot showing the PO summary card with status dropdown -->
+
+Once submitted, the supplier and line items are locked -- you can still update delivery dates and pickup addresses, but the core order details are fixed.
+
+### 4. Send to the supplier
+
+Use the **Email** button to send the PO to the supplier via email, or **Print** to generate a PDF you can send manually.
+
+If the supplier is set up in Xero, you can use the **Sync with Xero** button to push the PO through to Xero as well.
+
+### 5. Record deliveries
+
+As goods arrive, update the received quantities on each line item. The PO status will automatically move from "Submitted" to "Partially Received" and finally "Fully Received" as you record deliveries.
+
+## What Happens Next
+
+- The PO is tracked in the system with a clear status (Draft → Submitted → Partially Received → Fully Received)
+- Costs are allocated against the job(s) specified on each line
+- If synced to Xero, the PO appears there for accounting purposes
+- Material costs flow through to the job's Reality section and into the KPI reports
+
+## Tips
+
+::: tip
+Use the **Price TBC** checkbox when you know you need to order something but are waiting on a price. This lets you get the order started without holding things up.
+:::
+
+::: tip
+Add comments on the PO using the comments section at the bottom. This is handy for tracking conversations with the supplier about delivery changes, back-orders, etc.
+:::
+
+::: warning
+Once a PO is submitted, you can't change the supplier or line items. If you need to make changes, you'll need to delete the PO and create a new one. Double-check before submitting.
+:::

--- a/manual/quoting/assess-and-price.md
+++ b/manual/quoting/assess-and-price.md
@@ -4,51 +4,107 @@ title: Assess & Price a Job
 
 # Assess & Price a Job
 
-> **When to use:** You need to work out what to charge for a job before sending a quote.
+> **When to use:** You've got a job on the board and you need to work out what to charge before sending a quote.
 
 ## What You'll Need
 
-- [ ] Job details (from the enquiry)
-- [ ] Access to pricing information / rate cards
-- [ ] Site visit notes (if applicable)
+- [ ] A job already created in the system (from the enquiry)
+- [ ] A reasonable idea of what the work involves (site visit notes, photos, customer conversation)
+- [ ] Access to your rate cards (wage rates, charge-out rates, material costs)
 
 ## Steps
 
-### 1. Review the job requirements
+### 1. Open the job and go to the Estimate section
 
-<!-- PLACEHOLDER: Screenshot of job details view -->
+Navigate to the job and find the Estimate area. This is where you figure out whether the job is actually worth doing.
 
-[TODO: Where to find the job details, what to look for]
+<!-- PLACEHOLDER: Screenshot showing the Estimate section on a job page -->
 
-### 2. Estimate the work
+From a commercial perspective, jobs are divided into three parts: **time**, **materials**, and **adjustments**. The estimate mirrors this structure -- you'll see a section for each.
 
-[TODO: How to break down the work - labour, materials, etc.]
+Please don't skip this step. Are we in a financial mess because we've been taking on jobs without knowing if they're profitable, or because we've been taking on jobs despite knowing upfront that we wouldn't make money on them? The estimate is your "finger in the air" -- it doesn't need to be perfect, but it does need to exist.
 
-### 3. Apply pricing
+### 2. Estimate the time
 
-<!-- PLACEHOLDER: Screenshot of pricing/estimate entry -->
+The first grid covers labour. For each line you can enter:
 
-[TODO: How to enter estimate lines, where rates come from]
+| Column            | What it means                                        |
+| ----------------- | ---------------------------------------------------- |
+| **Description**   | What the work is (e.g. "Install signage", "4 folds") |
+| **Items**         | How many of this task                                |
+| **Mins/Hours**    | Time per item                                        |
+| **Total Minutes** | Calculated from Items x Mins/Hours                   |
+| **Wage Rate**     | What we pay the staff member per hour                |
+| **Charge Rate**   | What we charge the customer per hour                 |
 
-### 4. Review the total
+<!-- PLACEHOLDER: Screenshot showing the Time estimate grid with example entries -->
 
-[TODO: Sanity checking - does this look right? Margin check?]
+You can have just one line for the whole job, or break it into multiple lines -- e.g. "4 folds" on one line and "final installation" on another. Pragmatically, decide based on how big the job is. Small jobs just get a single total time; bigger jobs benefit from a breakdown so you can see where the hours go.
 
-### 5. Save the estimate
+### 3. Estimate the materials
 
-[TODO: What status does it go to? Ready for quote?]
+The second grid covers materials. For each line:
+
+| Column          | What it means                                     |
+| --------------- | ------------------------------------------------- |
+| **Item Code**   | Product or material code                          |
+| **Description** | What it is                                        |
+| **Quantity**    | How many / how much                               |
+| **Cost Rate**   | What we pay for it                                |
+| **Retail Rate** | What we charge the customer                       |
+| **Revenue**     | Calculated from Quantity x Retail Rate            |
+| **Comments**    | Anything worth noting (supplier, lead time, etc.) |
+
+<!-- PLACEHOLDER: Screenshot showing the Materials estimate grid with example entries -->
+
+Same principle as time -- one line for "materials" on a small job is fine. On a bigger job, break it out so you can see the margins on each item.
+
+### 4. Add any adjustments
+
+The third grid is for adjustments -- anything that doesn't fit neatly into time or materials. Think call-out fees, travel, discounts, or allowances.
+
+| Column               | What it means                           |
+| -------------------- | --------------------------------------- |
+| **Description**      | What the adjustment is for              |
+| **Cost Adjustment**  | What it costs us                        |
+| **Price Adjustment** | What we charge (or credit) the customer |
+| **Revenue**          | The net effect on revenue               |
+| **Comments**         | Context for anyone reviewing later      |
+
+<!-- PLACEHOLDER: Screenshot showing the Adjustments estimate grid -->
+
+### 5. Review the totals and check the margin
+
+Before you move on, look at the overall picture. Does the margin make sense? Does the total price feel right for the scope of work? If the numbers say we'll lose money, that's a conversation to have _now_ -- not after we've done the work.
+
+<!-- PLACEHOLDER: Screenshot showing the estimate totals and margin summary -->
+
+### 6. Copy the estimate to a quote
+
+Once you're happy with the estimate, hit the **Copy Estimate to Quote** button. This takes your workings and creates the customer-facing quote from them.
+
+<!-- PLACEHOLDER: Screenshot showing the "Copy Estimate to Quote" button -->
 
 ## What Happens Next
 
-- Estimate is saved on the job
-- Ready to [send the quote](/quoting/send-quote)
+- The estimate is saved on the job as your internal cost/price workings.
+- The quote is generated from the estimate, ready to review and send.
+- Next step: [Send the Quote](/quoting/send-quote) to the customer.
 
 ## Tips
 
 ::: tip
-[TODO: Pricing wisdom - e.g., "Always add 10% contingency for older buildings"]
+The estimate is for _us_ -- it's our internal view of cost vs. price. The quote is what the customer sees. You can be as detailed as you like in the estimate without worrying about what the customer will think.
+:::
+
+::: tip
+For small jobs, don't overthink it. One line for time, one line for materials, done. Save the detailed breakdowns for jobs where the complexity warrants it.
 :::
 
 ::: warning
-[TODO: Common mistake - e.g., "Forgetting to include call-out fee for small jobs"]
+Don't skip the estimate just because the job seems straightforward. A two-minute estimate that shows you'll make 15% margin is infinitely better than no estimate and a nasty surprise at invoicing time.
+:::
+
+::: warning
+If the estimate shows we'll lose money or barely break even, flag it before sending the quote. It's much easier to adjust pricing now than to explain a loss after the job is done.
 :::

--- a/manual/quoting/send-quote.md
+++ b/manual/quoting/send-quote.md
@@ -4,18 +4,53 @@ title: Send a Quote
 
 # Send a Quote
 
-> **When to use:** The estimate is ready and you need to send it to the customer.
+> **When to use:** The estimate is done, the quote section is filled in, and you need to get it in front of the customer.
 
 ## What You'll Need
 
-- [ ] Completed estimate on the job
-- [ ] Customer email address (or other contact method)
+- [ ] A completed estimate on the job (see [Assess & Price a Job](/quoting/assess-and-price))
+- [ ] The quote section populated (use the **Copy Estimate to Quote** button if you haven't already)
+- [ ] Customer email address or other contact method
 
 ## Steps
 
-[TODO: Document the quote sending process]
+### 1. Review the quote
+
+<!-- PLACEHOLDER: Screenshot showing the Quote tab on a job -->
+
+Open the job and go to the Quote section. The quote is what the customer will see, so check that it makes sense from their perspective. The structure is the same as the estimate -- time, materials, and adjustments -- but the numbers might differ.
+
+Remember: all jobs have an estimate, but only some have a quote. If it's a T&M (time and materials) job where you're billing as you go, you can skip the quote entirely and leave this section blank.
+
+### 2. Adjust if needed
+
+The **Copy Estimate to Quote** button gives you a starting point that matches your estimate exactly. From there you might want to:
+
+- Add some contingency (round up)
+- Reduce the price to win the job
+- Simplify the line items so the customer sees a cleaner breakdown
+
+The estimate stays unchanged as your internal record. The quote is the customer-facing version.
+
+### 3. Send the quote
+
+<!-- PLACEHOLDER: Screenshot showing the Quote Job button -->
+
+Use the **Quote Job** button to generate and send the quote to the customer. This creates a formatted quote document that goes out via email.
 
 ## What Happens Next
 
-- Customer receives the quote
-- [TODO: What happens when they accept/decline?]
+- The customer receives the quote by email
+- The job status updates to reflect that a quote has been sent
+- When the customer accepts, update the job status and move on to [scheduling](/scheduling/schedule-a-job)
+- If they decline or want changes, adjust the quote and resend
+
+## Tips
+
+::: tip
+If you used "Copy Estimate to Quote", double-check the numbers before sending. The estimate might have internal notes or line items that don't make sense to the customer.
+:::
+
+::: warning
+Don't send a quote without an estimate behind it. The estimate is how you know whether the job is profitable. Without it, you're guessing -- and guessing is how you lose money.
+:::

--- a/manual/scheduling/schedule-a-job.md
+++ b/manual/scheduling/schedule-a-job.md
@@ -4,19 +4,48 @@ title: Schedule a Job
 
 # Schedule a Job
 
-> **When to use:** A quoted job has been accepted and needs to be scheduled for work.
+> **When to use:** A quoted job has been accepted and needs to be assigned to staff for work.
 
 ## What You'll Need
 
-- [ ] Accepted quote / approved job
+- [ ] An accepted quote or approved job
 - [ ] Knowledge of staff availability
-- [ ] Customer's preferred timing
+- [ ] Customer's preferred timing (if any)
 
 ## Steps
 
-[TODO: Document the scheduling process]
+### 1. Find the job on the Kanban board
+
+<!-- PLACEHOLDER: Screenshot showing the Kanban board with jobs in various columns -->
+
+The Kanban board is your scheduling hub. Jobs that are ready to be scheduled will be sitting in the "Approved" column (or similar, depending on your workflow).
+
+### 2. Assign staff
+
+<!-- PLACEHOLDER: Screenshot showing the staff panel on the Kanban board -->
+
+Use the staff panel at the top of the Kanban board to assign team members to the job. You can see who's already assigned to other jobs to avoid overloading anyone.
+
+### 3. Move the job to the right column
+
+Drag the job card to the appropriate status column (e.g. "In Progress" or "Scheduled") to reflect that it's been assigned and is ready to go.
+
+### 4. Confirm with the customer
+
+Let the customer know when to expect the team on-site. If there are specific access requirements or timing constraints, add them to the job notes so field staff can see them.
 
 ## What Happens Next
 
-- Staff see the job on their schedule
-- Customer is notified of the date
+- Staff can see the job assigned to them on the Kanban board
+- The job status is visible to everyone in the office
+- Field staff do the work and record progress -- see [Complete a Job On-Site](/fieldwork/complete-a-job)
+
+## Tips
+
+::: tip
+Check the job estimate before scheduling. If the estimate shows 2 days of work, make sure you've allowed for that in the schedule rather than squeezing it into a half-day gap.
+:::
+
+::: warning
+Don't move a job to "In Progress" until it's actually been assigned to someone. An unassigned job in the wrong column just creates confusion.
+:::

--- a/manual/timesheets/end-of-day-entry.md
+++ b/manual/timesheets/end-of-day-entry.md
@@ -4,52 +4,80 @@ title: End of Day Entry
 
 # End of Day Entry
 
-> **When to use:** At the end of your work day, record the time spent on each job.
+> **When to use:** At the end of the day, you're entering time from staff time cards into the system.
 
 ## What You'll Need
 
-- [ ] List of jobs you worked on today
-- [ ] Approximate hours for each
-- [ ] Any materials used (if applicable)
+- [ ] Time cards from staff (with job numbers, descriptions, and hours)
+- [ ] Access to the Timesheets section
 
 ## Steps
 
-### 1. Open your timesheet
+### 1. Select the staff member and date
 
-<!-- PLACEHOLDER: Screenshot of timesheet view -->
+<!-- PLACEHOLDER: Screenshot showing the timesheet header with staff selector, date picker, and hours display -->
 
-[TODO: How to navigate to timesheet entry]
+Use the staff selector arrows at the top to pick whose time card you're entering. Set the date using the date picker, or hit **Today** to jump to the current date.
 
-### 2. Select the job
+The hours display in the header shows you at a glance how many hours have been entered versus the scheduled hours for that day. If the numbers don't match up, something's been missed.
 
-<!-- PLACEHOLDER: Screenshot of job selection -->
+### 2. Choose the job number
 
-[TODO: Explain the job search/selection process]
+<!-- PLACEHOLDER: Screenshot showing the job number field being selected in the timesheet entry grid -->
 
-### 3. Enter your hours
+Start by entering the job number. This will populate the job name and client automatically -- you don't need to type those in.
 
-[TODO: How to enter time - start/end vs hours? What about breaks?]
+### 3. Enter the description and hours
 
-### 4. Add materials (if needed)
+<!-- PLACEHOLDER: Screenshot showing a completed timesheet row with description and hours filled in -->
 
-[TODO: When and how to record materials used]
+Write the description and the time exactly as the person has written it on their time card. The grid columns are: Job Number, Job Name, Client Name, Description, Hours, Rate, Wage, Bill, Billable, Date, and Approval Status.
 
-### 5. Submit the entry
+### 4. Handle non-billable time
 
-[TODO: What happens when you submit]
+If it's not suitable to bill the client for the time -- say, fixing our own mistake -- untick the **Billable** checkbox. This way staff still get paid without overcharging the client or having to dump time onto shop jobs.
+
+You can add notes if you want, for example explaining why you unticked billable, but normally the description is enough.
+
+### 5. Check the daily summary
+
+<!-- PLACEHOLDER: Screenshot showing the Summary section with Total Hours, Billable Entries percentage, and Non-Billable Entries -->
+
+The summary at the bottom tells you how many hours the staff member has entered for this day. Use it to quickly check whether a full day has been entered. If you see 4.0 out of 8.0, someone's time card is incomplete.
+
+It also shows you the split between billable and non-billable entries so you can spot anything unusual.
+
+### 6. Review from the overview
+
+<!-- PLACEHOLDER: Screenshot showing the overview bar chart "Comparison of Estimated vs Actual Hours" with blue estimated and orange actual bars per job -->
+
+From the overview you can see all open jobs with the time spent versus the estimate. This is the bar chart view -- blue bars are estimated hours, orange bars are actual hours. If the orange is creeping past the blue, that job is going over budget.
+
+### 7. Check a staff member's jobs
+
+<!-- PLACEHOLDER: Screenshot showing the "Current Jobs" section with job cards displaying job number, name, client, status, estimated hours, and hours spent -->
+
+From any staff member's view you can see the jobs they've put time on that day. Each job card shows the job number, name, client, status, estimated hours, and hours spent.
+
+You can click on the job number (shown in blue) to jump straight to that job.
 
 ## What Happens Next
 
-- Your time is recorded against the job
-- [TODO: Does it affect invoicing? Job costing?]
-- [TODO: Who reviews timesheets?]
+- Time is recorded against the job and counts toward actual hours
+- The hours feed into job costing -- estimated vs actual is tracked automatically
+- Billable time will appear when it's time to invoice the client
+- Non-billable time is still tracked for payroll but won't be charged to the client
 
 ## Tips
 
 ::: tip
-[TODO: Best practice - e.g., "Enter time at the end of each day while it's fresh"]
+Enter time at the end of each day while it's fresh. Trying to reconstruct a week's worth of time cards on Friday afternoon never goes well.
+:::
+
+::: tip
+If you see a staff member consistently under their scheduled hours in the summary, check with them before assuming the time card is wrong -- they may have had a shorter day.
 :::
 
 ::: warning
-[TODO: Common mistake - e.g., "Forgetting travel time - always include it"]
+Don't just put non-billable time on a shop job to make it disappear. Use the billable checkbox on the actual job instead. That way you still have an accurate picture of how long the real job took -- you just aren't charging the client for it.
 :::

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
-    "manual:dev": "vitepress dev manual",
+    "manual:dev": "vitepress dev manual --port 5174",
     "manual:build": "vitepress build manual",
     "manual:preview": "vitepress preview manual",
     "manual:pdf": "vitepress-export-pdf export manual",

--- a/scripts/capture-screenshots.ts
+++ b/scripts/capture-screenshots.ts
@@ -37,12 +37,148 @@ const SCREENSHOTS: ScreenshotDef[] = [
     waitFor: '[data-automation-id="kanban-column"]',
   },
 
+  // === JOB CREATION ===
+  {
+    id: 'job-create-form',
+    description: 'Create new job form with client, name, and description fields',
+    route: '/jobs/create',
+    waitFor: 'form',
+  },
+
+  // === JOB DETAILS ===
+  {
+    id: 'job-details-form',
+    description: 'Job details form showing job number, name, client, and description',
+    route: '/kanban',
+    waitFor: '[data-automation-id="kanban-column"]',
+    prepare: async (page: Page) => {
+      // Click the first job card to open a job
+      const firstJob = page.locator('[data-automation-id="job-card"]').first()
+      if (await firstJob.isVisible()) {
+        await firstJob.click()
+        await page.waitForSelector('[data-automation-id="job-view"]', { timeout: 10000 })
+      }
+    },
+  },
+
+  // === JOB ESTIMATE TAB ===
+  {
+    id: 'job-estimate-tab',
+    description: 'Job Estimate tab showing time, materials, and adjustments grids',
+    route: '/kanban',
+    waitFor: '[data-automation-id="kanban-column"]',
+    prepare: async (page: Page) => {
+      const firstJob = page.locator('[data-automation-id="job-card"]').first()
+      if (await firstJob.isVisible()) {
+        await firstJob.click()
+        await page.waitForSelector('[data-automation-id="job-view"]', { timeout: 10000 })
+        // Click the Estimate tab
+        const estimateTab = page.getByRole('tab', { name: /estimate/i })
+        if (await estimateTab.isVisible()) await estimateTab.click()
+        await page.waitForTimeout(1000)
+      }
+    },
+    fullPage: true,
+  },
+
+  // === JOB QUOTE TAB ===
+  {
+    id: 'job-quote-tab',
+    description: 'Job Quote tab showing customer-facing pricing',
+    route: '/kanban',
+    waitFor: '[data-automation-id="kanban-column"]',
+    prepare: async (page: Page) => {
+      const firstJob = page.locator('[data-automation-id="job-card"]').first()
+      if (await firstJob.isVisible()) {
+        await firstJob.click()
+        await page.waitForSelector('[data-automation-id="job-view"]', { timeout: 10000 })
+        const quoteTab = page.getByRole('tab', { name: /quote/i })
+        if (await quoteTab.isVisible()) await quoteTab.click()
+        await page.waitForTimeout(1000)
+      }
+    },
+    fullPage: true,
+  },
+
+  // === JOB ACTUAL/REALITY TAB ===
+  {
+    id: 'job-actual-tab',
+    description: 'Job Reality/Actual tab showing real costs and revenue',
+    route: '/kanban',
+    waitFor: '[data-automation-id="kanban-column"]',
+    prepare: async (page: Page) => {
+      const firstJob = page.locator('[data-automation-id="job-card"]').first()
+      if (await firstJob.isVisible()) {
+        await firstJob.click()
+        await page.waitForSelector('[data-automation-id="job-view"]', { timeout: 10000 })
+        const actualTab = page.getByRole('tab', { name: /actual/i })
+        if (await actualTab.isVisible()) await actualTab.click()
+        await page.waitForTimeout(1000)
+      }
+    },
+    fullPage: true,
+  },
+
+  // === JOB ATTACHMENTS TAB ===
+  {
+    id: 'job-attachments-tab',
+    description: 'Job Attachments tab showing file upload area and attached files',
+    route: '/kanban',
+    waitFor: '[data-automation-id="kanban-column"]',
+    prepare: async (page: Page) => {
+      const firstJob = page.locator('[data-automation-id="job-card"]').first()
+      if (await firstJob.isVisible()) {
+        await firstJob.click()
+        await page.waitForSelector('[data-automation-id="job-view"]', { timeout: 10000 })
+        const attachTab = page.getByRole('tab', { name: /attachment/i })
+        if (await attachTab.isVisible()) await attachTab.click()
+        await page.waitForTimeout(1000)
+      }
+    },
+  },
+
   // === TIMESHEETS ===
   {
-    id: 'timesheet-daily-view',
-    description: 'Daily timesheet entry view',
+    id: 'timesheet-entry-grid',
+    description: 'Timesheet entry grid with staff selector, date picker, and hours',
+    route: '/timesheets/entry',
+    waitFor: 'main',
+  },
+  {
+    id: 'timesheet-daily-overview',
+    description: 'Daily timesheet overview with bar chart and staff hours',
     route: '/timesheets',
     waitFor: 'main',
+  },
+
+  // === PURCHASING ===
+  {
+    id: 'purchasing-po-list',
+    description: 'Purchase Orders list page',
+    route: '/purchasing/po',
+    waitFor: 'main',
+  },
+  {
+    id: 'purchasing-po-create',
+    description: 'Create Purchase Order form with supplier and reference fields',
+    route: '/purchasing/po/create',
+    waitFor: 'form',
+  },
+
+  // === REPORTS ===
+  {
+    id: 'kpi-report-overview',
+    description: 'KPI Report with summary cards and calendar heatmap',
+    route: '/reports/kpi',
+    waitFor: 'main',
+    fullPage: true,
+  },
+  {
+    id: 'payroll-reconciliation',
+    description: 'Payroll Reconciliation report with summary cards and heatmap grid',
+    route: '/reports/payroll-reconciliation',
+    waitFor: 'main',
+    fullPage: true,
   },
 
   // === CLIENTS ===
@@ -60,14 +196,12 @@ const SCREENSHOTS: ScreenshotDef[] = [
     route: '/company-defaults',
     waitFor: 'form',
   },
-
-  // Add more screenshots as needed...
-  // {
-  //   id: 'job-create-form',
-  //   description: 'Create new job form',
-  //   route: '/jobs/create',
-  //   waitFor: '[data-automation-id="job-form"]',
-  // },
+  {
+    id: 'admin-staff-list',
+    description: 'Staff Management page with staff table',
+    route: '/admin/staff',
+    waitFor: 'main',
+  },
 ]
 
 // Output paths

--- a/scripts/deploy_frontend.sh
+++ b/scripts/deploy_frontend.sh
@@ -40,6 +40,9 @@ main() {
 
     npm run build
 
+    # Build the training manual (served at /manual/)
+    npx vitepress build manual
+
     # Reload nginx to serve new build
     sudo systemctl reload nginx
 

--- a/src/components/AppNavbar.vue
+++ b/src/components/AppNavbar.vue
@@ -171,12 +171,14 @@
                 >
                   <Wrench class="w-4 h-4 mr-2" /> Machine Maintenance
                 </button>
-                <button
-                  @click="showNotImplemented('Staff Training')"
-                  class="w-full flex items-center px-4 py-2 text-sm text-gray-400 hover:text-gray-500 hover:bg-gray-50 font-medium transition-all"
+                <a
+                  href="/manual/"
+                  target="_blank"
+                  @click="activeDropdown = null"
+                  class="w-full flex items-center px-4 py-2 text-sm text-gray-700 hover:text-blue-600 hover:bg-gray-50 font-medium transition-all"
                 >
                   <GraduationCap class="w-4 h-4 mr-2" /> Staff Training
-                </button>
+                </a>
               </div>
             </Transition>
           </div>
@@ -590,12 +592,14 @@
                       >
                         <Wrench class="w-4 h-4 mr-2" /> Machine Maintenance
                       </button>
-                      <button
-                        @click="showNotImplementedMobile('Staff Training')"
-                        class="flex items-center w-full text-left px-2 py-1.5 text-sm text-gray-400 hover:text-gray-500 hover:bg-gray-50 rounded transition-all"
+                      <a
+                        href="/manual/"
+                        target="_blank"
+                        @click="closeMobileMenu()"
+                        class="flex items-center w-full text-left px-2 py-1.5 text-sm text-gray-700 hover:text-blue-600 hover:bg-gray-50 rounded transition-all"
                       >
                         <GraduationCap class="w-4 h-4 mr-2" /> Staff Training
-                      </button>
+                      </a>
                     </div>
                   </div>
                 </Transition>


### PR DESCRIPTION
## Summary

- Migrated content from the PDF training document into the VitePress training manual
- Filled all 9 existing recipe skeletons with real business-process content (estimates, timesheets, KPI reports, quoting, invoicing, scheduling, etc.)
- Added 5 new pages: job finances reference, file attachments, purchase orders, staff management, payroll reconciliation
- Wired up "Staff Training" navbar link (Process menu) to open `/manual/` in a new tab
- Configured VitePress to build at `/manual/` base path for production deployment
- Added manual build step to deploy script
- Extended screenshot capture script from 5 to 17 definitions
- Excluded VitePress cache from eslint
- Updated README with training manual dev commands
- Added VS Code tasks for local development

## Deployment

Requires one nginx config addition on the server:

```nginx
location /manual/ {
    alias /opt/workflow_app/jobs_manager_front/dist-manual/;
    try_files $uri $uri/ /manual/index.html;
}
```

## Test plan

- [x] `npm run type-check` passes
- [x] `npx vitepress build manual` produces all 14 pages
- [x] Unit tests pass (81/81)
- [x] Eslint clean
- [ ] Visual review of manual in browser (`npm run manual:dev`)
- [ ] Verify Staff Training navbar link opens manual
- [ ] Deploy to UAT and verify `/manual/` serves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)