### PR TITLE
ci: add Dependabot and stale PR cleanup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,17 @@
+name: Close stale PRs
+
+on:
+  schedule:
+    - cron: "0 9 * * 1"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-pr-message: "This PR has been inactive for 30 days. It will be closed in 7 days if there is no further activity."
+          days-before-pr-stale: 30
+          days-before-pr-close: 7
+          days-before-issue-stale: -1
+          days-before-issue-close: -1

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,7 +2,7 @@ name: Close stale PRs
 
 on:
   schedule:
-    - cron: "0 9 * * 1"
+    - cron: '0 9 * * 1'
 
 jobs:
   stale:
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          stale-pr-message: "This PR has been inactive for 30 days. It will be closed in 7 days if there is no further activity."
+          stale-pr-message: 'This PR has been inactive for 30 days. It will be closed in 7 days if there is no further activity.'
           days-before-pr-stale: 30
           days-before-pr-close: 7
           days-before-issue-stale: -1


### PR DESCRIPTION
Adds weekly Dependabot updates for npm and GitHub Actions, plus auto-close for stale PRs.