### PR TITLE
feat: RDTI Spend Report and hours formatting improvements

### DIFF
--- a/schema.yml
+++ b/schema.yml
@@ -178,6 +178,40 @@ paths:
                 type: object
                 additionalProperties: {}
           description: ''
+  /accounting/api/reports/rdti-spend/:
+    get:
+      operationId: accounting_api_reports_rdti_spend_retrieve
+      description: API endpoint for the RDTI spend report.
+      parameters:
+        - in: query
+          name: end_date
+          schema:
+            type: string
+          description: End date (YYYY-MM-DD)
+          required: true
+        - in: query
+          name: start_date
+          schema:
+            type: string
+          description: Start date (YYYY-MM-DD)
+          required: true
+      tags:
+        - accounting
+      security:
+        - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RDTISpendResponse'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardError'
+          description: ''
   /accounting/api/reports/sales-forecast/:
     get:
       operationId: sales_forecast_list
@@ -10378,6 +10412,15 @@ components:
           type: string
           readOnly: true
           nullable: true
+        staff:
+          type: string
+          format: uuid
+          nullable: true
+          description: Staff member this entry is about (e.g. inductee, trainee)
+        staff_name:
+          type: string
+          readOnly: true
+          nullable: true
         entry_date:
           type: string
           format: date
@@ -10406,6 +10449,7 @@ components:
         - form
         - id
         - job_number
+        - staff_name
     FormEntryRequest:
       type: object
       description: Serializer for FormEntry — filled-in instances of forms.
@@ -10415,6 +10459,11 @@ components:
           format: uuid
           nullable: true
           description: Linked job (e.g. incident forms)
+        staff:
+          type: string
+          format: uuid
+          nullable: true
+          description: Staff member this entry is about (e.g. inductee, trainee)
         entry_date:
           type: string
           format: date
@@ -10813,6 +10862,18 @@ components:
           type: boolean
           description: Indicates if this job was rejected (shown in Archived with
             rejected styling)
+        rdti_type:
+          nullable: true
+          description: |-
+            R&D Tax Incentive classification for this job
+
+            * `non_rd` - Non-R&D
+            * `core_rd` - Core R&D
+            * `supporting_rd` - Supporting R&D
+          oneOf:
+            - $ref: '#/components/schemas/RdtiTypeEnum'
+            - $ref: '#/components/schemas/BlankEnum'
+            - $ref: '#/components/schemas/NullEnum'
         default_xero_pay_item_id:
           type: string
           format: uuid
@@ -11693,6 +11754,18 @@ components:
           type: boolean
           description: Indicates if this job was rejected (shown in Archived with
             rejected styling)
+        rdti_type:
+          nullable: true
+          description: |-
+            R&D Tax Incentive classification for this job
+
+            * `non_rd` - Non-R&D
+            * `core_rd` - Core R&D
+            * `supporting_rd` - Supporting R&D
+          oneOf:
+            - $ref: '#/components/schemas/RdtiTypeEnum'
+            - $ref: '#/components/schemas/BlankEnum'
+            - $ref: '#/components/schemas/NullEnum'
       required:
         - client_id
         - client_name
@@ -12253,6 +12326,18 @@ components:
           type: boolean
           description: Indicates if this job was rejected (shown in Archived with
             rejected styling)
+        rdti_type:
+          nullable: true
+          description: |-
+            R&D Tax Incentive classification for this job
+
+            * `non_rd` - Non-R&D
+            * `core_rd` - Core R&D
+            * `supporting_rd` - Supporting R&D
+          oneOf:
+            - $ref: '#/components/schemas/RdtiTypeEnum'
+            - $ref: '#/components/schemas/BlankEnum'
+            - $ref: '#/components/schemas/NullEnum'
         default_xero_pay_item_id:
           type: string
           format: uuid
@@ -13868,6 +13953,11 @@ components:
           format: uuid
           nullable: true
           description: Linked job (e.g. incident forms)
+        staff:
+          type: string
+          format: uuid
+          nullable: true
+          description: Staff member this entry is about (e.g. inductee, trainee)
         entry_date:
           type: string
           format: date
@@ -15931,6 +16021,117 @@ components:
         * `ACCEPTED` - Accepted
         * `INVOICED` - Invoiced
         * `DELETED` - Deleted
+    RDTISpendCategorySummary:
+      type: object
+      description: Summary data for a single RDTI classification category.
+      properties:
+        rdti_type:
+          type: string
+        label:
+          type: string
+        hours:
+          type: number
+          format: double
+        cost:
+          type: number
+          format: double
+        revenue:
+          type: number
+          format: double
+        job_count:
+          type: integer
+      required:
+        - cost
+        - hours
+        - job_count
+        - label
+        - rdti_type
+        - revenue
+    RDTISpendJobDetail:
+      type: object
+      description: Per-job detail row in the RDTI spend report.
+      properties:
+        job_id:
+          type: string
+        job_number:
+          type: integer
+        job_name:
+          type: string
+        client_name:
+          type: string
+        rdti_type:
+          type: string
+        hours:
+          type: number
+          format: double
+        cost:
+          type: number
+          format: double
+        revenue:
+          type: number
+          format: double
+      required:
+        - client_name
+        - cost
+        - hours
+        - job_id
+        - job_name
+        - job_number
+        - rdti_type
+        - revenue
+    RDTISpendResponse:
+      type: object
+      description: Top-level response for the RDTI spend report.
+      properties:
+        start_date:
+          type: string
+          format: date
+        end_date:
+          type: string
+          format: date
+        summary:
+          type: array
+          items:
+            $ref: '#/components/schemas/RDTISpendCategorySummary'
+        jobs:
+          type: array
+          items:
+            $ref: '#/components/schemas/RDTISpendJobDetail'
+        totals:
+          $ref: '#/components/schemas/RDTISpendTotals'
+      required:
+        - end_date
+        - jobs
+        - start_date
+        - summary
+        - totals
+    RDTISpendTotals:
+      type: object
+      description: Grand totals across all RDTI categories.
+      properties:
+        hours:
+          type: number
+          format: double
+        cost:
+          type: number
+          format: double
+        revenue:
+          type: number
+          format: double
+      required:
+        - cost
+        - hours
+        - revenue
+    RdtiTypeEnum:
+      enum:
+        - non_rd
+        - core_rd
+        - supporting_rd
+      type: string
+      description: |-
+        * `non_rd` - Non-R&D
+        * `core_rd` - Core R&D
+        * `supporting_rd` - Supporting R&D
     RoleEnum:
       enum:
         - user

--- a/src/api/generated/api.ts
+++ b/src/api/generated/api.ts
@@ -197,6 +197,36 @@ const PayrollReconciliationResponse = z.object({
   heatmap: PayrollHeatmap,
   grand_totals: PayrollGrandTotals,
 })
+const RDTISpendCategorySummary = z.object({
+  rdti_type: z.string(),
+  label: z.string(),
+  hours: z.number(),
+  cost: z.number(),
+  revenue: z.number(),
+  job_count: z.number().int(),
+})
+const RDTISpendJobDetail = z.object({
+  job_id: z.string(),
+  job_number: z.number().int(),
+  job_name: z.string(),
+  client_name: z.string(),
+  rdti_type: z.string(),
+  hours: z.number(),
+  cost: z.number(),
+  revenue: z.number(),
+})
+const RDTISpendTotals = z.object({
+  hours: z.number(),
+  cost: z.number(),
+  revenue: z.number(),
+})
+const RDTISpendResponse = z.object({
+  start_date: z.string(),
+  end_date: z.string(),
+  summary: z.array(RDTISpendCategorySummary),
+  jobs: z.array(RDTISpendJobDetail),
+  totals: RDTISpendTotals,
+})
 const StaffPerformanceTeamAverages = z.object({
   billable_percentage: z.number(),
   revenue_per_hour: z.number(),
@@ -1337,6 +1367,9 @@ const XeroInvoice = z.object({
   status: InvoiceStatusEnum.optional(),
   online_url: z.string().max(200).url().nullish(),
 })
+const RdtiTypeEnum = z.enum(['non_rd', 'core_rd', 'supporting_rd'])
+const BlankEnum = z.unknown()
+const NullEnum = z.unknown()
 const Job = z.object({
   id: z.string().uuid(),
   name: z.string().max(100),
@@ -1372,6 +1405,7 @@ const Job = z.object({
   xero_invoices: z.array(XeroInvoice),
   shop_job: z.boolean(),
   rejected_flag: z.boolean().optional(),
+  rdti_type: z.union([RdtiTypeEnum, BlankEnum, NullEnum]).nullish(),
   default_xero_pay_item_id: z.string().uuid().nullish(),
   default_xero_pay_item_name: z.string().nullable(),
 })
@@ -1573,6 +1607,7 @@ const JobHeaderResponse = z.object({
   quote_acceptance_date: z.string().datetime({ offset: true }).nullish(),
   paid: z.boolean().optional(),
   rejected_flag: z.boolean().optional(),
+  rdti_type: z.union([RdtiTypeEnum, BlankEnum, NullEnum]).nullish(),
 })
 const JobInvoicesResponse = z.object({ invoices: z.array(Invoice) })
 const JobQuoteAcceptanceRequest = z.object({
@@ -1640,6 +1675,7 @@ const JobSummary = z.object({
   xero_invoices: z.array(XeroInvoice),
   shop_job: z.boolean(),
   rejected_flag: z.boolean().optional(),
+  rdti_type: z.union([RdtiTypeEnum, BlankEnum, NullEnum]).nullish(),
   default_xero_pay_item_id: z.string().uuid().nullish(),
   default_xero_pay_item_name: z.string().nullable(),
 })
@@ -1983,6 +2019,8 @@ const FormEntry = z.object({
   form: z.string().uuid(),
   job: z.string().uuid().nullish(),
   job_number: z.string().nullable(),
+  staff: z.string().uuid().nullish(),
+  staff_name: z.string().nullable(),
   entry_date: z.string(),
   entered_by: z.string().uuid().nullable(),
   entered_by_name: z.string().nullable(),
@@ -1991,12 +2029,14 @@ const FormEntry = z.object({
 })
 const FormEntryRequest = z.object({
   job: z.string().uuid().nullish(),
+  staff: z.string().uuid().nullish(),
   entry_date: z.string(),
   data: z.unknown().optional(),
 })
 const PatchedFormEntryRequest = z
   .object({
     job: z.string().uuid().nullable(),
+    staff: z.string().uuid().nullable(),
     entry_date: z.string(),
     data: z.unknown(),
   })
@@ -2287,8 +2327,6 @@ const MetalTypeEnum = z.enum([
   'unspecified',
   'other',
 ])
-const BlankEnum = z.unknown()
-const NullEnum = z.unknown()
 const PurchaseOrderLine = z.object({
   id: z.string().uuid(),
   description: z.string().max(200),
@@ -2796,6 +2834,10 @@ export const schemas = {
   PayrollHeatmap,
   PayrollGrandTotals,
   PayrollReconciliationResponse,
+  RDTISpendCategorySummary,
+  RDTISpendJobDetail,
+  RDTISpendTotals,
+  RDTISpendResponse,
   StaffPerformanceTeamAverages,
   StaffPerformanceJobBreakdown,
   StaffPerformanceStaffData,
@@ -2926,6 +2968,9 @@ export const schemas = {
   Invoice,
   XeroQuote,
   XeroInvoice,
+  RdtiTypeEnum,
+  BlankEnum,
+  NullEnum,
   Job,
   JobEvent,
   JobData,
@@ -3053,8 +3098,6 @@ export const schemas = {
   PurchasingErrorResponse,
   PurchaseOrderDetailStatusEnum,
   MetalTypeEnum,
-  BlankEnum,
-  NullEnum,
   PurchaseOrderLine,
   PurchaseOrderDetail,
   PurchaseOrderLineUpdateRequest,
@@ -3245,6 +3288,35 @@ Returns:
     alias: 'accounting_api_reports_profit_and_loss_retrieve',
     requestFormat: 'json',
     response: z.object({}).partial().passthrough(),
+  },
+  {
+    method: 'get',
+    path: '/accounting/api/reports/rdti-spend/',
+    alias: 'accounting_api_reports_rdti_spend_retrieve',
+    description: `API endpoint for the RDTI spend report.`,
+    requestFormat: 'json',
+    parameters: [
+      {
+        name: 'end_date',
+        type: 'Query',
+        schema: z.string(),
+      },
+      {
+        name: 'start_date',
+        type: 'Query',
+        schema: z.string(),
+      },
+    ],
+    response: RDTISpendResponse,
+    errors: [
+      {
+        status: 400,
+        schema: z.object({
+          error: z.string(),
+          details: z.unknown().optional(),
+        }),
+      },
+    ],
   },
   {
     method: 'get',

--- a/src/components/AppNavbar.vue
+++ b/src/components/AppNavbar.vue
@@ -254,6 +254,12 @@
                   <BarChart3 class="w-4 h-4 mr-2" /> KPI Reports
                 </router-link>
                 <router-link
+                  to="/reports/rdti-spend"
+                  class="flex items-center px-4 py-2 text-sm text-gray-700 hover:text-blue-600 hover:bg-blue-50 font-medium transition-all"
+                >
+                  <FlaskConical class="w-4 h-4 mr-2" /> RDTI Spend
+                </router-link>
+                <router-link
                   to="/reports/sales-forecast"
                   class="flex items-center px-4 py-2 text-sm text-gray-700 hover:text-blue-600 hover:bg-blue-50 font-medium transition-all"
                 >
@@ -694,6 +700,13 @@
                         <BarChart3 class="w-4 h-4 mr-2" /> KPI Reports
                       </router-link>
                       <router-link
+                        to="/reports/rdti-spend"
+                        class="flex items-center px-2 py-1.5 text-sm text-gray-600 hover:text-blue-600 hover:bg-blue-50 rounded transition-all"
+                        @click="closeMobileMenu"
+                      >
+                        <FlaskConical class="w-4 h-4 mr-2" /> RDTI Spend
+                      </router-link>
+                      <router-link
                         to="/reports/sales-forecast"
                         class="flex items-center px-2 py-1.5 text-sm text-gray-600 hover:text-blue-600 hover:bg-blue-50 rounded transition-all"
                         @click="closeMobileMenu"
@@ -823,6 +836,7 @@ import {
   Users,
   DollarSign,
   Scale,
+  FlaskConical,
 } from 'lucide-vue-next'
 import { useAppLayout } from '@/composables/useAppLayout'
 import { adminPages } from '@/config/adminPages'

--- a/src/components/job/JobSettingsTab.vue
+++ b/src/components/job/JobSettingsTab.vue
@@ -281,6 +281,27 @@
               </p>
             </div>
 
+            <div>
+              <label class="block text-sm font-medium text-gray-700 mb-2"
+                >RDTI Classification</label
+              >
+              <select
+                :value="localJobData.rdti_type || ''"
+                data-automation-id="JobSettingsTab-rdti-type"
+                @change="handleFieldInput('rdti_type', ($event.target as HTMLSelectElement).value)"
+                @blur="handleBlurFlush"
+                class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-colors"
+              >
+                <option value="">Unclassified</option>
+                <option value="non_rd">Non-R&amp;D</option>
+                <option value="core_rd">Core R&amp;D</option>
+                <option value="supporting_rd">Supporting R&amp;D</option>
+              </select>
+              <p class="mt-1 text-xs text-gray-500">
+                Research &amp; Development Tax Incentive classification for this job
+              </p>
+            </div>
+
             <div class="flex-grow">
               <RichTextEditor
                 :model-value="(localJobData.notes as string) || ''"
@@ -587,6 +608,8 @@ const handleFieldInput = (field: string, value: string) => {
     localJobData.value.pricing_methodology = newValue as Job['pricing_methodology']
   } else if (field === 'speed_quality_tradeoff') {
     localJobData.value.speed_quality_tradeoff = newValue as Job['speed_quality_tradeoff']
+  } else if (field === 'rdti_type') {
+    localJobData.value.rdti_type = (newValue || null) as Job['rdti_type']
   }
 
   // Queue autosave change
@@ -662,6 +685,7 @@ watch(
         price_cap: null,
         default_xero_pay_item_id: null,
         default_xero_pay_item_name: null,
+        rdti_type: null,
         // Include basic info fields - will be updated when basicInfo loads
         description: null,
         delivery_date: null,
@@ -695,6 +719,7 @@ watch(
       price_cap: newJobData.price_cap ?? null,
       default_xero_pay_item_id: newJobData.default_xero_pay_item_id ?? null,
       default_xero_pay_item_name: newJobData.default_xero_pay_item_name ?? null,
+      rdti_type: newJobData.rdti_type ?? null,
     }
 
     // Preserve existing basic info fields when updating with header data
@@ -1094,6 +1119,7 @@ const autosave = createJobAutosave({
       order_number: data.order_number || null,
       notes: data.notes || null,
       delivery_date: data.delivery_date || null,
+      rdti_type: data.rdti_type ?? null,
     }
   },
   applyOptimistic: (patch) => {
@@ -1193,6 +1219,7 @@ const autosave = createJobAutosave({
           next.order_number = (payload.order_number as string | null) ?? null
         if ('notes' in payload) next.notes = (payload.notes as string | null) ?? null
         if ('price_cap' in payload) next.price_cap = (payload.price_cap as number | null) ?? null
+        if ('rdti_type' in payload) next.rdti_type = (payload.rdti_type as Job['rdti_type']) ?? null
         return next
       }
 
@@ -1244,6 +1271,11 @@ const autosave = createJobAutosave({
           nextBaseline.pricing_methodology = serverJobDetail.pricing_methodology
           localJobData.value.pricing_methodology = serverJobDetail.pricing_methodology
           headerPatch.pricing_methodology = serverJobDetail.pricing_methodology
+        }
+        if (touchedKeys.includes('rdti_type')) {
+          nextBaseline.rdti_type = serverJobDetail.rdti_type ?? null
+          localJobData.value.rdti_type = serverJobDetail.rdti_type ?? null
+          headerPatch.rdti_type = serverJobDetail.rdti_type ?? null
         }
         if (touchedKeys.includes('speed_quality_tradeoff')) {
           nextBaseline.speed_quality_tradeoff = serverJobDetail.speed_quality_tradeoff
@@ -1356,6 +1388,12 @@ const autosave = createJobAutosave({
           nextBaseline.pricing_methodology = pricingVal as Job['pricing_methodology']
           localJobData.value.pricing_methodology = pricingVal as Job['pricing_methodology']
           headerPatch.pricing_methodology = pricingVal as Job['pricing_methodology']
+        }
+        if (touchedKeys.includes('rdti_type')) {
+          const rdtiVal = coerceNullableString(partialPayload.rdti_type)
+          nextBaseline.rdti_type = (rdtiVal ?? null) as Job['rdti_type']
+          localJobData.value.rdti_type = (rdtiVal ?? null) as Job['rdti_type']
+          headerPatch.rdti_type = (rdtiVal ?? null) as Job['rdti_type']
         }
         if (touchedKeys.includes('speed_quality_tradeoff')) {
           const tradeoffVal =
@@ -1512,6 +1550,7 @@ onMounted(() => {
           status: response.status,
           pricing_methodology: response.pricing_methodology,
           speed_quality_tradeoff: response.speed_quality_tradeoff ?? 'normal',
+          rdti_type: response.rdti_type ?? null,
           fully_invoiced: response.fully_invoiced,
           quoted: response.quoted,
           quote_acceptance_date: response.quote_acceptance_date,

--- a/src/components/kpi/KPICalendarDay.vue
+++ b/src/components/kpi/KPICalendarDay.vue
@@ -62,7 +62,7 @@
 import { computed } from 'vue'
 import { schemas } from '@/api/generated/api'
 import { z } from 'zod'
-import { formatCurrency } from '@/utils/string-formatting'
+import { formatCurrency, formatHoursDisplay } from '@/utils/string-formatting'
 
 type DayKPI = z.infer<typeof schemas.KPIDayData>
 type Thresholds = z.infer<typeof schemas.KPIThresholds>
@@ -99,7 +99,7 @@ const adjustmentProfit = computed(() => {
 })
 
 function formatHours(hours: number): string {
-  return `${Math.round(hours)}h`
+  return formatHoursDisplay(hours)
 }
 </script>
 

--- a/src/components/shared/CompactSummaryCard.vue
+++ b/src/components/shared/CompactSummaryCard.vue
@@ -55,9 +55,9 @@
       <!-- Total Hours -->
       <div class="flex justify-between items-center">
         <span class="text-xs text-gray-500">Total Hours</span>
-        <span class="text-sm font-semibold text-blue-600"
-          >{{ formatNumber(typedSummary.hours) }} hrs</span
-        >
+        <span class="text-sm font-semibold text-blue-600">{{
+          formatHoursDisplay(typedSummary.hours)
+        }}</span>
       </div>
     </div>
 
@@ -73,7 +73,7 @@ import { computed } from 'vue'
 import { FileX, Maximize2 } from 'lucide-vue-next'
 import { Button } from '../ui/button'
 import { schemas } from '../../api/generated/api'
-import { formatCurrency } from '@/utils/string-formatting'
+import { formatCurrency, formatHoursDisplay } from '@/utils/string-formatting'
 import { z } from 'zod'
 
 type CostLine = z.infer<typeof schemas.CostLine>
@@ -151,13 +151,6 @@ const profit = computed(() => {
   if (!typedSummary.value) return 0
   return typedSummary.value.rev - typedSummary.value.cost
 })
-
-function formatNumber(value: number): string {
-  return new Intl.NumberFormat('en-US', {
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 2,
-  }).format(value)
-}
 </script>
 
 <style scoped>

--- a/src/components/shared/CostSetSummaryCard.vue
+++ b/src/components/shared/CostSetSummaryCard.vue
@@ -101,9 +101,9 @@
             </div>
             <div class="flex flex-col">
               <span class="text-xs text-gray-500">Total Hours</span>
-              <span class="text-lg font-semibold text-blue-600"
-                >{{ formatNumber(typedSummary.hours) }} hrs</span
-              >
+              <span class="text-lg font-semibold text-blue-600">{{
+                formatHoursDisplay(typedSummary.hours)
+              }}</span>
             </div>
           </div>
         </div>
@@ -122,7 +122,7 @@
 import { computed } from 'vue'
 import { FileX } from 'lucide-vue-next'
 import { schemas } from '../../api/generated/api'
-import { formatCurrency } from '@/utils/string-formatting'
+import { formatCurrency, formatHoursDisplay } from '@/utils/string-formatting'
 import { z } from 'zod'
 
 type CostLine = z.infer<typeof schemas.CostLine>
@@ -271,13 +271,6 @@ const breakdown = computed(() => {
   console.log('[CostSetSummaryCard] breakdown result:', result)
   return result
 })
-
-function formatNumber(value: number): string {
-  return new Intl.NumberFormat('en-US', {
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 2,
-  }).format(value)
-}
 
 function formatPercentage(value: number): string {
   return new Intl.NumberFormat('en-US', {

--- a/src/components/timesheet/PayrollStaffRow.vue
+++ b/src/components/timesheet/PayrollStaffRow.vue
@@ -61,12 +61,12 @@
           <div
             v-if="hasOvertime(idx)"
             class="h-1 lg:h-1.5 w-1 lg:w-1.5 bg-orange-500 rounded-full"
-            :title="`Overtime: ${formatHours(getTotalOvertime(idx))}h`"
+            :title="`Overtime: ${formatHours(getTotalOvertime(idx))}`"
           ></div>
           <div
             v-if="hasLeave(idx)"
             class="h-1 lg:h-1.5 w-1 lg:w-1.5 bg-blue-500 rounded-full"
-            :title="`Leave: ${formatHours(getTotalLeave(idx))}h`"
+            :title="`Leave: ${formatHours(getTotalLeave(idx))}`"
           ></div>
         </div>
 
@@ -76,25 +76,25 @@
         >
           <div class="space-y-0.5 lg:space-y-1">
             <div v-if="staff.weekly_hours[idx].billed_hours" class="text-xs lg:text-sm">
-              Billed: {{ formatHours(staff.weekly_hours[idx].billed_hours) }}h
+              Billed: {{ formatHours(staff.weekly_hours[idx].billed_hours) }}
             </div>
             <div v-if="staff.weekly_hours[idx].unbilled_hours" class="text-xs lg:text-sm">
-              Unbilled: {{ formatHours(staff.weekly_hours[idx].unbilled_hours) }}h
+              Unbilled: {{ formatHours(staff.weekly_hours[idx].unbilled_hours) }}
             </div>
             <div v-if="staff.weekly_hours[idx].overtime_1_5x_hours" class="text-xs lg:text-sm">
-              1.5x Time: {{ formatHours(staff.weekly_hours[idx].overtime_1_5x_hours) }}h
+              1.5x Time: {{ formatHours(staff.weekly_hours[idx].overtime_1_5x_hours) }}
             </div>
             <div v-if="staff.weekly_hours[idx].overtime_2x_hours" class="text-xs lg:text-sm">
-              2x Time: {{ formatHours(staff.weekly_hours[idx].overtime_2x_hours) }}h
+              2x Time: {{ formatHours(staff.weekly_hours[idx].overtime_2x_hours) }}
             </div>
             <div v-if="staff.weekly_hours[idx].sick_leave_hours" class="text-xs lg:text-sm">
-              Sick Leave: {{ formatHours(staff.weekly_hours[idx].sick_leave_hours) }}h
+              Sick Leave: {{ formatHours(staff.weekly_hours[idx].sick_leave_hours) }}
             </div>
             <div v-if="staff.weekly_hours[idx].annual_leave_hours" class="text-xs lg:text-sm">
-              Annual Leave: {{ formatHours(staff.weekly_hours[idx].annual_leave_hours) }}h
+              Annual Leave: {{ formatHours(staff.weekly_hours[idx].annual_leave_hours) }}
             </div>
             <div v-if="staff.weekly_hours[idx].bereavement_leave_hours" class="text-xs lg:text-sm">
-              Bereavement Leave: {{ formatHours(staff.weekly_hours[idx].bereavement_leave_hours) }}h
+              Bereavement Leave: {{ formatHours(staff.weekly_hours[idx].bereavement_leave_hours) }}
             </div>
           </div>
           <div
@@ -115,34 +115,34 @@
           <Check
             v-if="staff.total_billed_hours > 0"
             class="h-3 w-3 lg:h-3.5 lg:w-3.5 text-green-600"
-            :title="`Billed: ${formatHours(staff.total_billed_hours)}h`"
+            :title="`Billed: ${formatHours(staff.total_billed_hours)}`"
           />
           <X
             v-if="staff.total_unbilled_hours > 0"
             class="h-3 w-3 lg:h-3.5 lg:w-3.5 text-gray-500"
-            :title="`Unbilled: ${formatHours(staff.total_unbilled_hours)}h`"
+            :title="`Unbilled: ${formatHours(staff.total_unbilled_hours)}`"
           />
           <span
             v-if="staff.total_overtime_1_5x_hours > 0"
             class="text-[10px] lg:text-xs font-bold text-orange-600"
-            :title="`1.5x Time: ${formatHours(staff.total_overtime_1_5x_hours)}h`"
+            :title="`1.5x Time: ${formatHours(staff.total_overtime_1_5x_hours)}`"
             >1.5</span
           >
           <span
             v-if="staff.total_overtime_2x_hours > 0"
             class="text-[10px] lg:text-xs font-bold text-red-600"
-            :title="`2x Time: ${formatHours(staff.total_overtime_2x_hours)}h`"
+            :title="`2x Time: ${formatHours(staff.total_overtime_2x_hours)}`"
             >2x</span
           >
           <Heart
             v-if="staff.total_sick_leave_hours > 0"
             class="h-3 w-3 lg:h-3.5 lg:w-3.5 text-blue-600"
-            :title="`Sick Leave: ${formatHours(staff.total_sick_leave_hours)}h`"
+            :title="`Sick Leave: ${formatHours(staff.total_sick_leave_hours)}`"
           />
           <Plane
             v-if="staff.total_annual_leave_hours > 0"
             class="h-3 w-3 lg:h-3.5 lg:w-3.5 text-purple-600"
-            :title="`Annual Leave: ${formatHours(staff.total_annual_leave_hours)}h`"
+            :title="`Annual Leave: ${formatHours(staff.total_annual_leave_hours)}`"
           />
         </div>
       </div>
@@ -151,7 +151,7 @@
     <!-- Billable Hours Column -->
     <td class="px-1.5 lg:px-2 py-1.5 lg:py-2 text-center">
       <span class="text-sm lg:text-base font-medium text-gray-700">
-        {{ formatHours(staff.total_billable_hours) }}h
+        {{ formatHours(staff.total_billable_hours) }}
       </span>
     </td>
 
@@ -184,9 +184,9 @@
         </span>
       </td>
       <td class="px-1.5 lg:px-2 py-1 lg:py-1.5 text-center">
-        <span class="text-xs lg:text-sm font-medium text-green-700"
-          >{{ formatHours(staff.total_billed_hours) }}h</span
-        >
+        <span class="text-xs lg:text-sm font-medium text-green-700">{{
+          formatHours(staff.total_billed_hours)
+        }}</span>
       </td>
       <td class="px-1.5 lg:px-2 py-1 lg:py-1.5"></td>
       <td class="px-1.5 lg:px-2 py-1 lg:py-1.5"></td>
@@ -211,9 +211,9 @@
         </span>
       </td>
       <td class="px-1.5 lg:px-2 py-1 lg:py-1.5 text-center">
-        <span class="text-xs lg:text-sm font-medium text-gray-700"
-          >{{ formatHours(staff.total_unbilled_hours) }}h</span
-        >
+        <span class="text-xs lg:text-sm font-medium text-gray-700">{{
+          formatHours(staff.total_unbilled_hours)
+        }}</span>
       </td>
       <td class="px-1.5 lg:px-2 py-1 lg:py-1.5"></td>
       <td class="px-1.5 lg:px-2 py-1 lg:py-1.5"></td>
@@ -238,9 +238,9 @@
         </span>
       </td>
       <td class="px-1.5 lg:px-2 py-1 lg:py-1.5 text-center">
-        <span class="text-xs lg:text-sm font-medium text-orange-700"
-          >{{ formatHours(staff.total_overtime_1_5x_hours) }}h</span
-        >
+        <span class="text-xs lg:text-sm font-medium text-orange-700">{{
+          formatHours(staff.total_overtime_1_5x_hours)
+        }}</span>
       </td>
       <td class="px-1.5 lg:px-2 py-1 lg:py-1.5"></td>
       <td class="px-1.5 lg:px-2 py-1 lg:py-1.5"></td>
@@ -265,9 +265,9 @@
         </span>
       </td>
       <td class="px-1.5 lg:px-2 py-1 lg:py-1.5 text-center">
-        <span class="text-xs lg:text-sm font-medium text-red-700"
-          >{{ formatHours(staff.total_overtime_2x_hours) }}h</span
-        >
+        <span class="text-xs lg:text-sm font-medium text-red-700">{{
+          formatHours(staff.total_overtime_2x_hours)
+        }}</span>
       </td>
       <td class="px-1.5 lg:px-2 py-1 lg:py-1.5"></td>
       <td class="px-1.5 lg:px-2 py-1 lg:py-1.5"></td>
@@ -292,9 +292,9 @@
         </span>
       </td>
       <td class="px-1.5 lg:px-2 py-1 lg:py-1.5 text-center">
-        <span class="text-xs lg:text-sm font-medium text-blue-700"
-          >{{ formatHours(staff.total_sick_leave_hours) }}h</span
-        >
+        <span class="text-xs lg:text-sm font-medium text-blue-700">{{
+          formatHours(staff.total_sick_leave_hours)
+        }}</span>
       </td>
       <td class="px-1.5 lg:px-2 py-1 lg:py-1.5"></td>
       <td class="px-1.5 lg:px-2 py-1 lg:py-1.5"></td>
@@ -319,9 +319,9 @@
         </span>
       </td>
       <td class="px-1.5 lg:px-2 py-1 lg:py-1.5 text-center">
-        <span class="text-xs lg:text-sm font-medium text-purple-700"
-          >{{ formatHours(staff.total_annual_leave_hours) }}h</span
-        >
+        <span class="text-xs lg:text-sm font-medium text-purple-700">{{
+          formatHours(staff.total_annual_leave_hours)
+        }}</span>
       </td>
       <td class="px-1.5 lg:px-2 py-1 lg:py-1.5"></td>
       <td class="px-1.5 lg:px-2 py-1 lg:py-1.5"></td>
@@ -405,7 +405,7 @@ function getDayTooltip(day: WeeklyDayData, idx: number): string {
 
   const overtime = getTotalOvertime(idx)
   if (overtime > 0) {
-    parts.push(`Overtime: ${formatHours(overtime)}h`)
+    parts.push(`Overtime: ${formatHours(overtime)}`)
   }
 
   return parts.length > 0 ? parts.join(' | ') : 'No data'

--- a/src/components/timesheet/StaffRow.vue
+++ b/src/components/timesheet/StaffRow.vue
@@ -40,12 +40,12 @@
     <div class="grid grid-cols-3 gap-1.5 lg:gap-2 text-center">
       <div>
         <div class="text-xs lg:text-sm text-gray-500">Hours</div>
-        <div class="text-sm lg:text-base font-medium">{{ formatHours(staff.actual_hours) }}h</div>
+        <div class="text-sm lg:text-base font-medium">{{ formatHours(staff.actual_hours) }}</div>
       </div>
       <div>
         <div class="text-xs lg:text-sm text-gray-500">Scheduled</div>
         <div class="text-sm lg:text-base font-medium">
-          {{ formatHours(staff.scheduled_hours) }}h
+          {{ formatHours(staff.scheduled_hours) }}
         </div>
       </div>
       <div>
@@ -108,11 +108,10 @@
     <td class="px-1.5 lg:px-2 py-1.5 lg:py-2 whitespace-nowrap text-center">
       <div class="text-sm lg:text-base">
         <div class="font-medium text-gray-900 leading-tight">
-          {{ formatHours(staff.actual_hours)
-          }}<span class="text-xs lg:text-sm text-gray-500">h</span>
+          {{ formatHours(staff.actual_hours) }}
         </div>
         <div class="text-xs lg:text-sm text-gray-500 leading-tight">
-          / {{ formatHours(staff.scheduled_hours) }}h
+          / {{ formatHours(staff.scheduled_hours) }}
         </div>
 
         <div class="w-6 lg:w-8 bg-gray-200 rounded-full h-0.5 lg:h-1 mx-auto mt-0.5 lg:mt-1">

--- a/src/components/timesheet/StaffWeekRow.vue
+++ b/src/components/timesheet/StaffWeekRow.vue
@@ -21,7 +21,7 @@
             class="flex items-center space-x-1"
           >
             <span class="text-xs lg:text-sm text-orange-600 font-medium">
-              OT: {{ formatHours(staff.total_overtime_hours) }}h
+              OT: {{ formatHours(staff.total_overtime_hours) }}
             </span>
           </div>
         </div>
@@ -56,12 +56,12 @@
           <div
             v-if="hasOvertime(idx)"
             class="h-1 lg:h-1.5 w-1 lg:w-1.5 bg-orange-500 rounded-full"
-            :title="`Overtime: ${formatHours(getTotalOvertime(idx))}h`"
+            :title="`Overtime: ${formatHours(getTotalOvertime(idx))}`"
           ></div>
           <div
             v-if="hasLeave(idx)"
             class="h-1 lg:h-1.5 w-1 lg:w-1.5 bg-blue-500 rounded-full"
-            :title="`Leave: ${formatHours(getTotalLeave(idx))}h`"
+            :title="`Leave: ${formatHours(getTotalLeave(idx))}`"
           ></div>
         </div>
 
@@ -72,25 +72,25 @@
         >
           <div class="space-y-0.5 lg:space-y-1">
             <div v-if="staff.weekly_hours[idx].billed_hours" class="text-xs lg:text-sm">
-              Billed: {{ formatHours(staff.weekly_hours[idx].billed_hours) }}h
+              Billed: {{ formatHours(staff.weekly_hours[idx].billed_hours) }}
             </div>
             <div v-if="staff.weekly_hours[idx].unbilled_hours" class="text-xs lg:text-sm">
-              Unbilled: {{ formatHours(staff.weekly_hours[idx].unbilled_hours) }}h
+              Unbilled: {{ formatHours(staff.weekly_hours[idx].unbilled_hours) }}
             </div>
             <div v-if="staff.weekly_hours[idx].overtime_1_5x_hours" class="text-xs lg:text-sm">
-              1.5x Time: {{ formatHours(staff.weekly_hours[idx].overtime_1_5x_hours) }}h
+              1.5x Time: {{ formatHours(staff.weekly_hours[idx].overtime_1_5x_hours) }}
             </div>
             <div v-if="staff.weekly_hours[idx].overtime_2x_hours" class="text-xs lg:text-sm">
-              2x Time: {{ formatHours(staff.weekly_hours[idx].overtime_2x_hours) }}h
+              2x Time: {{ formatHours(staff.weekly_hours[idx].overtime_2x_hours) }}
             </div>
             <div v-if="staff.weekly_hours[idx].sick_leave_hours" class="text-xs lg:text-sm">
-              Sick Leave: {{ formatHours(staff.weekly_hours[idx].sick_leave_hours) }}h
+              Sick Leave: {{ formatHours(staff.weekly_hours[idx].sick_leave_hours) }}
             </div>
             <div v-if="staff.weekly_hours[idx].annual_leave_hours" class="text-xs lg:text-sm">
-              Annual Leave: {{ formatHours(staff.weekly_hours[idx].annual_leave_hours) }}h
+              Annual Leave: {{ formatHours(staff.weekly_hours[idx].annual_leave_hours) }}
             </div>
             <div v-if="staff.weekly_hours[idx].bereavement_leave_hours" class="text-xs lg:text-sm">
-              Bereavement Leave: {{ formatHours(staff.weekly_hours[idx].bereavement_leave_hours) }}h
+              Bereavement Leave: {{ formatHours(staff.weekly_hours[idx].bereavement_leave_hours) }}
             </div>
           </div>
           <div
@@ -189,7 +189,7 @@ const getDayTooltip = (day: WeeklyDayData, idx: number): string => {
 
   const overtime = getTotalOvertime(idx)
   if (overtime > 0) {
-    parts.push(`Overtime: ${formatHours(overtime)}h`)
+    parts.push(`Overtime: ${formatHours(overtime)}`)
   }
 
   return parts.length > 0 ? parts.join(' | ') : 'No data'

--- a/src/components/timesheet/SummaryDrawer.vue
+++ b/src/components/timesheet/SummaryDrawer.vue
@@ -32,7 +32,7 @@
                   <div class="min-w-0">
                     <p class="text-xs md:text-sm text-gray-600">Total Hours</p>
                     <p class="text-base md:text-lg font-semibold">
-                      {{ formatHoursDisplay(consolidatedSummary.totalHours) }}h
+                      {{ formatHoursDisplay(consolidatedSummary.totalHours) }}
                     </p>
                   </div>
                 </div>
@@ -128,8 +128,8 @@
                       <div class="flex justify-between text-sm">
                         <span class="text-gray-600">Hours Progress</span>
                         <span class="font-medium">
-                          {{ formatHoursDisplay(jobData.actualHours) }}h /
-                          {{ formatHoursDisplay(jobData.estimatedHours) }}h
+                          {{ formatHoursDisplay(jobData.actualHours) }} /
+                          {{ formatHoursDisplay(jobData.estimatedHours) }}
                         </span>
                       </div>
 

--- a/src/components/workshop/WorkshopTimeUsedTable.vue
+++ b/src/components/workshop/WorkshopTimeUsedTable.vue
@@ -16,6 +16,7 @@ import { computed, onMounted, ref, watch } from 'vue'
 import { schemas } from '@/api/generated/api'
 import { api } from '@/api/client'
 import type { z } from 'zod'
+import { formatHoursDisplay } from '@/utils/string-formatting'
 
 type CostLine = z.infer<typeof schemas.CostLine>
 type KanbanStaff = z.infer<typeof schemas.KanbanStaff>
@@ -102,14 +103,12 @@ function staffNameFor(line: CostLine) {
 
 function formatHours(value: number | null) {
   if (value == null || Number.isNaN(value)) return '-'
-  const rounded = Math.round(value * 10) / 10
-  return Number.isInteger(rounded) ? rounded.toFixed(0) : rounded.toFixed(1)
+  return formatHoursDisplay(value)
 }
 
 function formatRemaining(value: number | null) {
   if (value == null || Number.isNaN(value)) return '-'
-  const rounded = Math.round(value * 10) / 10
-  return Number.isInteger(rounded) ? rounded.toFixed(0) : rounded.toFixed(1)
+  return formatHoursDisplay(value)
 }
 
 onMounted(async () => {

--- a/src/components/workshop/WorkshopTimesheetEntryDrawer.vue
+++ b/src/components/workshop/WorkshopTimesheetEntryDrawer.vue
@@ -12,6 +12,7 @@ import {
 } from '@/components/ui/drawer'
 import { Ban, Save, Shuffle, Trash2 } from 'lucide-vue-next'
 import { computed } from 'vue'
+import { formatHoursDisplay } from '@/utils/string-formatting'
 
 interface FormState {
   jobId: string
@@ -143,7 +144,7 @@ const isBillable = computed({
               <div>
                 Duration:
                 <span class="font-semibold text-foreground">
-                  {{ formDurationHours.toFixed(2) }} h
+                  {{ formatHoursDisplay(formDurationHours) }}
                 </span>
               </div>
               <div class="flex flex-wrap gap-2 text-xs">

--- a/src/components/workshop/WorkshopTimesheetLegacyTable.vue
+++ b/src/components/workshop/WorkshopTimesheetLegacyTable.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { schemas } from '@/api/generated/api'
 import { AlertTriangle, Pencil, Trash2 } from 'lucide-vue-next'
+import { formatHoursDisplay } from '@/utils/string-formatting'
 import type { z } from 'zod'
 
 type WorkshopTimesheetEntry = z.infer<typeof schemas.WorkshopTimesheetEntry>
@@ -76,7 +77,7 @@ const emit = defineEmits<{
               </div>
             </td>
             <td class="px-3 py-3 text-right font-semibold text-sm whitespace-nowrap">
-              {{ entry.hours.toFixed(2) }} h
+              {{ formatHoursDisplay(entry.hours) }}
             </td>
             <td class="px-3 py-2">
               <div class="flex items-center gap-2">

--- a/src/components/workshop/WorkshopTimesheetSummaryCard.vue
+++ b/src/components/workshop/WorkshopTimesheetSummaryCard.vue
@@ -3,6 +3,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { AlertTriangle, CalendarDays, Plus, RefreshCcw } from 'lucide-vue-next'
+import { formatHoursDisplay } from '@/utils/string-formatting'
 
 interface Props {
   formattedDate: string
@@ -38,7 +39,8 @@ const emit = defineEmits<{
           </Badge>
         </CardTitle>
         <p class="text-sm text-muted-foreground">
-          {{ selectedDaySummary.hours.toFixed(2) }} h &middot; {{ selectedDaySummary.jobs }} jobs
+          {{ formatHoursDisplay(selectedDaySummary.hours) }} &middot;
+          {{ selectedDaySummary.jobs }} jobs
         </p>
       </div>
       <div class="flex items-center gap-2">

--- a/src/composables/useTimesheetEntryGrid.ts
+++ b/src/composables/useTimesheetEntryGrid.ts
@@ -148,7 +148,7 @@ export function useTimesheetEntryGrid(
         const isOvertime = hours > 8
         const color = isOvertime ? '#DC2626' : '#374151'
         const weight = isOvertime ? '600' : '400'
-        return `<span style="color: ${color}; font-weight: ${weight};">${formatHoursDisplay(hours)}h</span>`
+        return `<span style="color: ${color}; font-weight: ${weight};">${formatHoursDisplay(hours)}</span>`
       },
       cellClass: 'text-right',
     },

--- a/src/composables/useWorkshopCalendarSync.ts
+++ b/src/composables/useWorkshopCalendarSync.ts
@@ -9,6 +9,7 @@ import {
   formatTimeInputValue,
 } from '@/composables/useWorkshopTimesheetTimeUtils'
 import { formatDateKey } from '@/composables/useWorkshopTimesheetDay'
+import { formatHoursDisplay } from '@/utils/string-formatting'
 import type { ComponentPublicInstance } from 'vue'
 import type { z } from 'zod'
 import type { JobBudgetMeta } from '@/composables/useWorkshopJobBudgets'
@@ -82,7 +83,7 @@ export function useWorkshopCalendarSync(options: {
       ) ||
       entry.hours ||
       0
-    const durationLabel = duration ? `${duration.toFixed(2)}h` : ''
+    const durationLabel = duration ? formatHoursDisplay(duration) : ''
     return [jobNumber, jobName, durationLabel ? `(${durationLabel})` : ''].filter(Boolean).join(' ')
   }
 
@@ -94,7 +95,7 @@ export function useWorkshopCalendarSync(options: {
     const overBudget = budgetMeta?.overBudget ?? false
     const budgetTooltip =
       budgetMeta && budgetMeta.overBudget
-        ? `Over estimate: ${formatHoursValue(budgetMeta.actualHours)}h / ${formatHoursValue(budgetMeta.estimatedHours)}h`
+        ? `Over estimate: ${formatHoursValue(budgetMeta.actualHours)} / ${formatHoursValue(budgetMeta.estimatedHours)}`
         : ''
     return {
       id: entry.id,

--- a/src/composables/useWorkshopJob.ts
+++ b/src/composables/useWorkshopJob.ts
@@ -4,6 +4,7 @@ import { jobService } from '@/services/job.service'
 import { toast } from 'vue-sonner'
 import DOMPurify from 'dompurify'
 import type { z } from 'zod'
+import { formatHoursDisplay } from '@/utils/string-formatting'
 
 type Job = z.infer<typeof schemas.Job>
 type JobSummary = z.infer<typeof schemas.JobSummary>
@@ -58,8 +59,7 @@ export function useWorkshopJob(jobId: Ref<string>) {
   const workshopTimeDisplay = computed(() => {
     const hours = workshopTime.value.hours
     if (hours === null) return '-'
-    const rounded = Math.round(hours * 10) / 10
-    return `${Number.isInteger(rounded) ? rounded.toFixed(0) : rounded.toFixed(1)} h`
+    return formatHoursDisplay(hours)
   })
 
   async function loadJob() {

--- a/src/composables/useWorkshopJobBudgets.ts
+++ b/src/composables/useWorkshopJobBudgets.ts
@@ -37,7 +37,7 @@ export function useWorkshopJobBudgets(selectedJobIds: ComputedRef<string[]>) {
     return overBudgetJobs.value
       .map(
         (meta) =>
-          `#${meta.job.job_number} ${meta.job.name}: ${formatHoursValue(meta.actualHours)}h / ${formatHoursValue(meta.estimatedHours)}h`,
+          `#${meta.job.job_number} ${meta.job.name}: ${formatHoursValue(meta.actualHours)} / ${formatHoursValue(meta.estimatedHours)}`,
       )
       .join('\n')
   })

--- a/src/composables/useWorkshopTimesheetTimeUtils.ts
+++ b/src/composables/useWorkshopTimesheetTimeUtils.ts
@@ -1,4 +1,5 @@
 import dayjs from 'dayjs'
+import { formatHoursDisplay } from '@/utils/string-formatting'
 
 export function ensureTimeWithSeconds(time: string): string {
   if (!time) return '00:00:00'
@@ -52,7 +53,5 @@ export function calculateDurationHours(startTime: string, endTime: string): numb
 }
 
 export function formatHoursValue(hours: number): string {
-  const safe = Number.isFinite(hours) ? hours : 0
-  const rounded = Math.round(safe * 100) / 100
-  return parseFloat(rounded.toFixed(2)).toString()
+  return formatHoursDisplay(hours)
 }

--- a/src/plugins/ag-grid.ts
+++ b/src/plugins/ag-grid.ts
@@ -1,6 +1,6 @@
 import { ModuleRegistry, AllCommunityModule, themeQuartz } from 'ag-grid-community'
 import type { ValueFormatterParams } from 'ag-grid-community'
-import { formatCurrency } from '@/utils/string-formatting'
+import { formatCurrency, formatHoursDisplay } from '@/utils/string-formatting'
 
 ModuleRegistry.registerModules([AllCommunityModule])
 
@@ -67,7 +67,7 @@ export const defaultGridOptions = {
       cellClass: 'numeric-cell hours-cell',
       valueFormatter: (params: ValueFormatterParams) => {
         if (params.value == null) return ''
-        return `${Number(params.value).toFixed(2)}h`
+        return formatHoursDisplay(Number(params.value))
       },
     },
   },

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -264,6 +264,12 @@ const router = createRouter({
       },
     },
     {
+      path: '/reports/rdti-spend',
+      name: 'rdti-spend-report',
+      component: () => import('@/views/RDTISpendReportView.vue'),
+      meta: { requiresAuth: true, title: 'RDTI Spend Report - Jobs Manager', allowScroll: true },
+    },
+    {
       path: '/reports/payroll-reconciliation',
       name: 'payroll-reconciliation-report',
       component: () => import('@/views/PayrollReconciliationReportView.vue'),

--- a/src/services/kpi.service.ts
+++ b/src/services/kpi.service.ts
@@ -2,7 +2,7 @@ import { api } from '@/api/client'
 import { schemas } from '@/api/generated/api'
 import { debugLog } from '@/utils/debug'
 import { toLocalDateString } from '@/utils/dateUtils'
-import { formatCurrency } from '@/utils/string-formatting'
+import { formatCurrency, formatHoursDisplay } from '@/utils/string-formatting'
 import type { z } from 'zod'
 
 // Types for params - keeping as local since they're for input validation
@@ -81,7 +81,7 @@ class KPIService {
   }
 
   formatHours(hours: number): string {
-    return `${Math.round(hours)}h`
+    return formatHoursDisplay(hours)
   }
 
   formatPercentage(value: number): string {

--- a/src/services/staff-performance-report.service.ts
+++ b/src/services/staff-performance-report.service.ts
@@ -132,7 +132,7 @@ export class StaffPerformanceReportService {
   }
 
   formatHours(hours: number): string {
-    return `${formatHoursDisplay(hours)}h`
+    return formatHoursDisplay(hours)
   }
 
   formatPercentage(percentage: number): string {

--- a/src/services/timesheet.service.ts
+++ b/src/services/timesheet.service.ts
@@ -3,6 +3,7 @@ import { schemas } from '@/api/generated/api'
 import { api } from '@/api/client'
 import { debugLog } from '../utils/debug'
 import { toLocalDateString } from '../utils/dateUtils'
+import { formatHoursDisplay } from '@/utils/string-formatting'
 import type { z } from 'zod'
 
 type Staff = z.infer<typeof schemas.ModernStaff>
@@ -98,7 +99,7 @@ export class TimesheetService {
   }
 
   static formatHours(hours: number): string {
-    return hours.toFixed(2)
+    return formatHoursDisplay(hours)
   }
 
   static async getStaffList(): Promise<Staff[]> {

--- a/src/stores/timesheet.ts
+++ b/src/stores/timesheet.ts
@@ -8,6 +8,7 @@ import type { z } from 'zod'
 import { toast } from 'vue-sonner'
 import { FeatureFlagsService } from '@/services/feature-flags.service'
 import { validateFields } from '@/utils/contractValidation'
+import { formatHoursDisplay } from '@/utils/string-formatting'
 type CostLineMeta = Record<string, unknown> & {
   date?: string
   staff_id?: string
@@ -565,7 +566,7 @@ export const useTimesheetStore = defineStore('timesheet', () => {
   }
 
   function formatHours(hours: number): string {
-    return hours.toFixed(2)
+    return formatHoursDisplay(hours)
   }
 
   function addAttachedJob(job: Job) {

--- a/src/utils/string-formatting.ts
+++ b/src/utils/string-formatting.ts
@@ -97,12 +97,18 @@ export function formatCurrency(value: number | null | undefined, { decimals = 2 
 }
 
 /**
- * Formats hours to 2 decimal places, trimming trailing zeros.
- * e.g. 1 → "1", 1.5 → "1.5", 3.75 → "3.75"
+ * Formats hours as human-readable hours and minutes.
+ * e.g. 0 → "0h", 0.2 → "12m", 1 → "1h", 1.5 → "1h 30m", 3.2 → "3h 12m"
  */
 export function formatHoursDisplay(hours: number | null | undefined): string {
-  if (hours === null || hours === undefined || !Number.isFinite(hours)) return '0'
-  return parseFloat(hours.toFixed(2)).toString()
+  if (hours === null || hours === undefined || !Number.isFinite(hours)) return '0h'
+  const totalMinutes = Math.round(hours * 60)
+  const h = Math.floor(totalMinutes / 60)
+  const m = totalMinutes % 60
+  if (h === 0 && m === 0) return '0h'
+  if (h === 0) return `${m}m`
+  if (m === 0) return `${h}h`
+  return `${h}h ${m}m`
 }
 
 /**

--- a/src/views/AdminMonthEnd.vue
+++ b/src/views/AdminMonthEnd.vue
@@ -136,7 +136,7 @@
                   /></TableCell>
                   <TableCell>{{ job.job_number }}</TableCell>
                   <TableCell>{{ job.job_name }}</TableCell>
-                  <TableCell>{{ job.total_hours.toFixed(2) }}</TableCell>
+                  <TableCell>{{ formatHoursDisplay(job.total_hours) }}</TableCell>
                   <TableCell>{{ job.total_dollars.toFixed(2) }}</TableCell>
                   <TableCell>
                     <svg class="w-24 h-6">
@@ -255,6 +255,7 @@ import { toast } from 'vue-sonner'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
 import MonthEndSummary from '@/components/admin/MonthEndSummary.vue'
 import { debugLog } from '../utils/debug'
+import { formatHoursDisplay } from '@/utils/string-formatting'
 
 interface MonthTab {
   key: string

--- a/src/views/KPIReportsView.vue
+++ b/src/views/KPIReportsView.vue
@@ -336,7 +336,7 @@ import MonthSelector from '@/components/kpi/MonthSelector.vue'
 import { kpiService } from '@/services/kpi.service'
 import type { KPICalendarResponse, DayKPI } from '@/services/kpi.service'
 import { BarChart3, Download, RefreshCw, Settings } from 'lucide-vue-next'
-import { formatCurrency } from '@/utils/string-formatting'
+import { formatCurrency, formatHoursDisplay } from '@/utils/string-formatting'
 
 const router = useRouter()
 const loading = ref(false)
@@ -397,7 +397,7 @@ async function fetchKPIData() {
 
 const avgBillableHoursDisplay = computed(() => {
   if (!kpiData.value) return '0h'
-  return `${kpiData.value.monthly_totals.avg_billable_hours_so_far.toFixed(1)}h`
+  return formatHoursDisplay(kpiData.value.monthly_totals.avg_billable_hours_so_far)
 })
 
 const utilizationTrend = computed(() => {

--- a/src/views/RDTISpendReportView.vue
+++ b/src/views/RDTISpendReportView.vue
@@ -1,0 +1,438 @@
+<template>
+  <AppLayout>
+    <div class="w-full h-full flex flex-col overflow-hidden">
+      <div class="flex-1 overflow-y-auto p-0">
+        <div class="max-w-7xl mx-auto py-8 px-2 md:px-8 flex flex-col gap-6">
+          <!-- Header -->
+          <div class="flex items-center justify-between mb-4">
+            <h1 class="text-3xl font-extrabold text-indigo-700 flex items-center gap-3">
+              <FlaskConical class="w-8 h-8 text-indigo-400" />
+              RDTI Spend Report
+            </h1>
+            <div class="flex items-center gap-2">
+              <Button
+                variant="outline"
+                @click="exportReport"
+                :disabled="loading || !jobs.length"
+                class="text-sm px-4 py-2"
+              >
+                <Download class="w-4 h-4 mr-2" />
+                Export CSV
+              </Button>
+              <Button
+                variant="default"
+                @click="loadData"
+                :disabled="loading"
+                class="text-sm px-4 py-2"
+              >
+                <RefreshCw class="w-4 h-4 mr-2" :class="{ 'animate-spin': loading }" />
+                Refresh
+              </Button>
+            </div>
+          </div>
+
+          <!-- Filters -->
+          <div class="bg-white rounded-lg shadow-sm border border-slate-200 p-4">
+            <div class="flex flex-wrap items-end gap-4">
+              <div class="flex items-center gap-2">
+                <label for="start-date" class="text-sm font-medium text-gray-700">
+                  Start Date:
+                </label>
+                <input
+                  id="start-date"
+                  v-model="filters.startDate"
+                  type="date"
+                  class="rounded border-gray-300 text-sm focus:ring-indigo-500 focus:border-indigo-500"
+                />
+              </div>
+              <div class="flex items-center gap-2">
+                <label for="end-date" class="text-sm font-medium text-gray-700"> End Date: </label>
+                <input
+                  id="end-date"
+                  v-model="filters.endDate"
+                  type="date"
+                  class="rounded border-gray-300 text-sm focus:ring-indigo-500 focus:border-indigo-500"
+                />
+              </div>
+              <Button variant="default" size="sm" @click="loadData" :disabled="loading">
+                Apply Filters
+              </Button>
+            </div>
+            <div class="flex gap-2 mt-3">
+              <Button variant="outline" size="sm" @click="setDateRange('thisFinancialYear')">
+                This Financial Year
+              </Button>
+              <Button variant="outline" size="sm" @click="setDateRange('lastFinancialYear')">
+                Last Financial Year
+              </Button>
+              <Button variant="outline" size="sm" @click="setDateRange('thisQuarter')">
+                This Quarter
+              </Button>
+              <Button variant="outline" size="sm" @click="setDateRange('thisMonth')">
+                This Month
+              </Button>
+            </div>
+          </div>
+
+          <!-- Summary Cards -->
+          <div
+            v-if="totals && !loading"
+            class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4"
+          >
+            <div class="bg-white rounded-lg shadow-sm border border-slate-200 p-4">
+              <p class="text-sm font-medium text-gray-600">Total R&D Hours</p>
+              <p class="text-2xl font-bold text-gray-900">
+                {{ formatHoursDisplay(totals.hours) }}
+              </p>
+            </div>
+            <div class="bg-white rounded-lg shadow-sm border border-slate-200 p-4">
+              <p class="text-sm font-medium text-gray-600">Total R&D Cost</p>
+              <p class="text-2xl font-bold text-gray-900">
+                {{ formatCurrency(totals.cost) }}
+              </p>
+            </div>
+            <div class="bg-white rounded-lg shadow-sm border border-slate-200 p-4">
+              <p class="text-sm font-medium text-gray-600">Core R&D Cost</p>
+              <p class="text-2xl font-bold text-gray-900">
+                {{ formatCurrency(coreSummary?.cost ?? 0) }}
+              </p>
+            </div>
+            <div class="bg-white rounded-lg shadow-sm border border-slate-200 p-4">
+              <p class="text-sm font-medium text-gray-600">Supporting R&D Cost</p>
+              <p class="text-2xl font-bold text-gray-900">
+                {{ formatCurrency(supportingSummary?.cost ?? 0) }}
+              </p>
+            </div>
+          </div>
+
+          <!-- Loading State -->
+          <div v-if="loading" class="flex items-center justify-center py-12">
+            <RefreshCw class="h-8 w-8 animate-spin text-indigo-500" />
+            <span class="ml-2 text-lg text-gray-600">Loading RDTI spend data...</span>
+          </div>
+
+          <!-- Error State -->
+          <div v-else-if="error" class="bg-red-50 border border-red-200 rounded-lg p-4">
+            <div class="flex items-center">
+              <AlertCircle class="h-5 w-5 text-red-400 mr-2" />
+              <span class="text-red-800">{{ error }}</span>
+            </div>
+          </div>
+
+          <!-- Data Table -->
+          <div
+            v-else-if="jobs.length > 0"
+            class="bg-white rounded-lg shadow-sm border border-slate-200 overflow-hidden"
+          >
+            <div class="px-4 py-5 sm:p-6">
+              <div class="overflow-x-auto">
+                <table class="min-w-full divide-y divide-gray-200">
+                  <thead class="bg-gray-50">
+                    <tr>
+                      <th
+                        class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-slate-100"
+                        @click="handleSort('job_number')"
+                      >
+                        <div class="flex items-center gap-1">
+                          Job #
+                          <span v-if="sortColumn === 'job_number'" class="text-slate-500">
+                            {{ sortDirection === 'asc' ? '↑' : '↓' }}
+                          </span>
+                        </div>
+                      </th>
+                      <th
+                        class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-slate-100"
+                        @click="handleSort('job_name')"
+                      >
+                        <div class="flex items-center gap-1">
+                          Job Name
+                          <span v-if="sortColumn === 'job_name'" class="text-slate-500">
+                            {{ sortDirection === 'asc' ? '↑' : '↓' }}
+                          </span>
+                        </div>
+                      </th>
+                      <th
+                        class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-slate-100"
+                        @click="handleSort('client_name')"
+                      >
+                        <div class="flex items-center gap-1">
+                          Client
+                          <span v-if="sortColumn === 'client_name'" class="text-slate-500">
+                            {{ sortDirection === 'asc' ? '↑' : '↓' }}
+                          </span>
+                        </div>
+                      </th>
+                      <th
+                        class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-slate-100"
+                        @click="handleSort('rdti_type')"
+                      >
+                        <div class="flex items-center gap-1">
+                          RDTI Type
+                          <span v-if="sortColumn === 'rdti_type'" class="text-slate-500">
+                            {{ sortDirection === 'asc' ? '↑' : '↓' }}
+                          </span>
+                        </div>
+                      </th>
+                      <th
+                        class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-slate-100"
+                        @click="handleSort('hours')"
+                      >
+                        <div class="flex items-center justify-end gap-1">
+                          Hours
+                          <span v-if="sortColumn === 'hours'" class="text-slate-500">
+                            {{ sortDirection === 'asc' ? '↑' : '↓' }}
+                          </span>
+                        </div>
+                      </th>
+                      <th
+                        class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-slate-100"
+                        @click="handleSort('cost')"
+                      >
+                        <div class="flex items-center justify-end gap-1">
+                          Cost
+                          <span v-if="sortColumn === 'cost'" class="text-slate-500">
+                            {{ sortDirection === 'asc' ? '↑' : '↓' }}
+                          </span>
+                        </div>
+                      </th>
+                      <th
+                        class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-slate-100"
+                        @click="handleSort('revenue')"
+                      >
+                        <div class="flex items-center justify-end gap-1">
+                          Revenue
+                          <span v-if="sortColumn === 'revenue'" class="text-slate-500">
+                            {{ sortDirection === 'asc' ? '↑' : '↓' }}
+                          </span>
+                        </div>
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody class="bg-white divide-y divide-gray-200">
+                    <tr v-for="job in sortedJobs" :key="job.job_id" class="hover:bg-gray-50">
+                      <td class="px-4 py-4 whitespace-nowrap text-sm">
+                        <router-link
+                          :to="`/jobs/${job.job_id}`"
+                          class="text-indigo-600 hover:text-indigo-900 font-medium"
+                        >
+                          {{ job.job_number }}
+                        </router-link>
+                      </td>
+                      <td
+                        class="px-4 py-4 whitespace-nowrap text-sm text-gray-900 max-w-[200px] truncate"
+                        :title="job.job_name"
+                      >
+                        {{ job.job_name }}
+                      </td>
+                      <td
+                        class="px-4 py-4 whitespace-nowrap text-sm text-gray-900 max-w-[150px] truncate"
+                        :title="job.client_name"
+                      >
+                        {{ job.client_name }}
+                      </td>
+                      <td class="px-4 py-4 whitespace-nowrap text-sm">
+                        <span
+                          class="inline-flex px-2 py-0.5 text-xs font-semibold rounded-full"
+                          :class="
+                            job.rdti_type === 'core'
+                              ? 'bg-indigo-100 text-indigo-800'
+                              : 'bg-amber-100 text-amber-800'
+                          "
+                        >
+                          {{ job.rdti_type === 'core' ? 'Core' : 'Supporting' }}
+                        </span>
+                      </td>
+                      <td class="px-4 py-4 whitespace-nowrap text-sm text-gray-900 text-right">
+                        {{ formatHoursDisplay(job.hours) }}
+                      </td>
+                      <td class="px-4 py-4 whitespace-nowrap text-sm text-gray-900 text-right">
+                        {{ formatCurrency(job.cost) }}
+                      </td>
+                      <td class="px-4 py-4 whitespace-nowrap text-sm text-gray-900 text-right">
+                        {{ formatCurrency(job.revenue) }}
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+
+          <!-- Empty State -->
+          <div v-else class="bg-white rounded-lg shadow-sm border border-slate-200 p-8 text-center">
+            <FlaskConical class="mx-auto h-12 w-12 text-gray-400" />
+            <h3 class="mt-2 text-sm font-medium text-gray-900">No RDTI spend data</h3>
+            <p class="mt-1 text-sm text-gray-500">
+              No RDTI classified jobs found for the selected date range. Try adjusting the filters.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </AppLayout>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { FlaskConical, Download, RefreshCw, AlertCircle } from 'lucide-vue-next'
+import AppLayout from '@/components/AppLayout.vue'
+import { Button } from '@/components/ui/button'
+import { api } from '@/api/client'
+import { formatCurrency, formatHoursDisplay, exportToCsv } from '@/utils/string-formatting'
+import { toLocalDateString } from '@/utils/dateUtils'
+import { toast } from 'vue-sonner'
+import { useFinancialYear } from '@/composables/useFinancialYear'
+import type { z } from 'zod'
+import { schemas } from '@/api/generated/api'
+
+type RDTISpendCategorySummary = z.infer<typeof schemas.RDTISpendCategorySummary>
+type RDTISpendJobDetail = z.infer<typeof schemas.RDTISpendJobDetail>
+type RDTISpendTotals = z.infer<typeof schemas.RDTISpendTotals>
+
+const { getDateRange: getFyDateRange } = useFinancialYear()
+
+const loading = ref(false)
+const error = ref<string | null>(null)
+const jobs = ref<RDTISpendJobDetail[]>([])
+const summary = ref<RDTISpendCategorySummary[]>([])
+const totals = ref<RDTISpendTotals | null>(null)
+
+const filters = ref({
+  startDate: '',
+  endDate: '',
+})
+
+const coreSummary = computed(() => summary.value.find((s) => s.rdti_type === 'core'))
+const supportingSummary = computed(() => summary.value.find((s) => s.rdti_type === 'supporting'))
+
+type SortableColumn =
+  | 'job_number'
+  | 'job_name'
+  | 'client_name'
+  | 'rdti_type'
+  | 'hours'
+  | 'cost'
+  | 'revenue'
+
+const sortColumn = ref<SortableColumn | null>(null)
+const sortDirection = ref<'asc' | 'desc'>('asc')
+
+const getSortValue = (job: RDTISpendJobDetail, col: SortableColumn): string | number => {
+  switch (col) {
+    case 'job_number':
+      return job.job_number
+    case 'hours':
+      return job.hours
+    case 'cost':
+      return job.cost
+    case 'revenue':
+      return job.revenue
+    default:
+      return job[col] ?? ''
+  }
+}
+
+const sortedJobs = computed(() => {
+  if (!sortColumn.value) return jobs.value
+
+  return [...jobs.value].sort((a, b) => {
+    const col = sortColumn.value as SortableColumn
+    const aVal = getSortValue(a, col)
+    const bVal = getSortValue(b, col)
+
+    if (typeof aVal === 'number' && typeof bVal === 'number') {
+      return sortDirection.value === 'asc' ? aVal - bVal : bVal - aVal
+    }
+
+    const comparison = String(aVal).localeCompare(String(bVal))
+    return sortDirection.value === 'asc' ? comparison : -comparison
+  })
+})
+
+const handleSort = (column: SortableColumn) => {
+  if (sortColumn.value === column) {
+    sortDirection.value = sortDirection.value === 'asc' ? 'desc' : 'asc'
+  } else {
+    sortColumn.value = column
+    sortDirection.value = 'asc'
+  }
+}
+
+const setDateRange = (
+  period: 'thisFinancialYear' | 'lastFinancialYear' | 'thisQuarter' | 'thisMonth',
+) => {
+  const now = new Date()
+
+  switch (period) {
+    case 'thisFinancialYear':
+    case 'lastFinancialYear': {
+      const range = getFyDateRange(period)
+      filters.value.startDate = range.startDate
+      filters.value.endDate = range.endDate
+      break
+    }
+    case 'thisQuarter': {
+      const quarterMonth = Math.floor(now.getMonth() / 3) * 3
+      const start = new Date(now.getFullYear(), quarterMonth, 1)
+      filters.value.startDate = toLocalDateString(start)
+      filters.value.endDate = toLocalDateString(now)
+      break
+    }
+    case 'thisMonth': {
+      const start = new Date(now.getFullYear(), now.getMonth(), 1)
+      filters.value.startDate = toLocalDateString(start)
+      filters.value.endDate = toLocalDateString(now)
+      break
+    }
+  }
+  loadData()
+}
+
+const loadData = async () => {
+  if (!filters.value.startDate || !filters.value.endDate) return
+
+  loading.value = true
+  error.value = null
+
+  try {
+    const response = await api.accounting_api_reports_rdti_spend_retrieve({
+      queries: { start_date: filters.value.startDate, end_date: filters.value.endDate },
+    })
+
+    jobs.value = response.jobs
+    summary.value = response.summary
+    totals.value = response.totals
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Failed to load RDTI spend data'
+    jobs.value = []
+    summary.value = []
+    totals.value = null
+    toast.error('Failed to load RDTI spend report')
+  } finally {
+    loading.value = false
+  }
+}
+
+const exportReport = () => {
+  if (!jobs.value.length) return
+
+  const headers = ['Job Number', 'Job Name', 'Client', 'RDTI Type', 'Hours', 'Cost', 'Revenue']
+
+  const rows = jobs.value.map((job) => [
+    job.job_number,
+    job.job_name,
+    job.client_name,
+    job.rdti_type,
+    job.hours,
+    job.cost,
+    job.revenue,
+  ])
+
+  exportToCsv(headers, rows, `rdti-spend-report-${toLocalDateString()}`)
+  toast.success('Report exported successfully')
+}
+
+onMounted(() => {
+  setDateRange('thisFinancialYear')
+})
+</script>

--- a/src/views/TimesheetEntryView.vue
+++ b/src/views/TimesheetEntryView.vue
@@ -66,7 +66,7 @@
               <span class="font-semibold" :class="hoursStatusClass">{{
                 formatHoursDisplay(todayStats.totalHours)
               }}</span>
-              <span class="text-gray-400"> / {{ formatHoursDisplay(scheduledHours) }}h</span>
+              <span class="text-gray-400"> / {{ formatHoursDisplay(scheduledHours) }}</span>
             </div>
           </div>
 
@@ -246,7 +246,7 @@
               <span class="font-semibold" :class="hoursStatusClass">{{
                 formatHoursDisplay(todayStats.totalHours)
               }}</span>
-              <span class="text-gray-400"> / {{ formatHoursDisplay(scheduledHours) }}h</span>
+              <span class="text-gray-400"> / {{ formatHoursDisplay(scheduledHours) }}</span>
             </div>
 
             <Button
@@ -405,9 +405,9 @@
                         <div class="flex justify-between text-xs">
                           <span class="text-gray-600">Progress</span>
                           <span class="font-medium">
-                            {{ formatHoursDisplay(jobData.actualHours) }}h
+                            {{ formatHoursDisplay(jobData.actualHours) }}
                             <span v-if="jobData.estimatedHours > 0">
-                              / {{ formatHoursDisplay(jobData.estimatedHours) }}h
+                              / {{ formatHoursDisplay(jobData.estimatedHours) }}
                             </span>
                           </span>
                         </div>
@@ -438,7 +438,7 @@
                               {{ jobData.completionPercentage.toFixed(1) }}% complete
                             </span>
                             <span v-else>
-                              {{ formatHoursDisplay(jobData.actualHours) }}h logged
+                              {{ formatHoursDisplay(jobData.actualHours) }} logged
                             </span>
                           </span>
                           <span v-if="jobData.isOverBudget" class="text-red-600 font-medium">
@@ -490,7 +490,7 @@
                                 formatHoursDisplay(consolidatedSummary.totalHours)
                               }}</span>
                               <span class="text-sm font-normal text-gray-400"
-                                >/ {{ formatHoursDisplay(scheduledHours) }}h</span
+                                >/ {{ formatHoursDisplay(scheduledHours) }}</span
                               >
                             </p>
                           </div>

--- a/src/views/WeeklyTimesheetView.vue
+++ b/src/views/WeeklyTimesheetView.vue
@@ -259,7 +259,7 @@
                     </td>
                     <td class="px-1.5 lg:px-2 py-2 lg:py-3 text-center">
                       <span class="text-sm lg:text-base font-bold text-gray-900">
-                        {{ formatHours(getTotalBillableHours()) }}h
+                        {{ formatHours(getTotalBillableHours()) }}
                       </span>
                     </td>
                     <td class="px-1.5 lg:px-2 py-2 lg:py-3 text-center">


### PR DESCRIPTION
## Summary
- Add RDTI Spend Report view (`/reports/rdti-spend`) with summary cards (total hours, total cost, core/supporting breakdown), sortable detail table, date range filters with quick presets, and CSV export
- Add RDTI Classification dropdown to Job Settings tab
- Display hours as Xh Ym format instead of decimal across the app

## Test plan
- [ ] Navigate to `/reports/rdti-spend` from Reports > RDTI Spend in navbar
- [ ] Verify summary cards show total R&D hours, total cost, core cost, and supporting cost
- [ ] Verify date filters and quick presets (This FY, Last FY, This Quarter, This Month) work
- [ ] Verify table sorting works on all columns
- [ ] Verify job number links navigate to the correct job
- [ ] Verify Export CSV downloads correctly
- [ ] Verify RDTI Classification dropdown appears in Job Settings tab
- [ ] Verify hours display as Xh Ym format throughout the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)